### PR TITLE
ci: fix main-branch build + helm chart publish

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -7,11 +7,12 @@ on:
       - "main"
 
 env:
-  git-user: github-actions[bot]
-  git-email: 41898282+github-actions[bot]@users.noreply.github.com
   HELM_DOCS_VERSION: 1.11.0
-  CHART_REPOSITORY: https://storage.googleapis.com/botkube-latest-main-charts
-  LATEST_PLUGIN_INDEX_URL: https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml
+  CHART_OCI_REPO: oci://ghcr.io/${{ github.repository_owner }}/charts
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   process-chart:
@@ -42,22 +43,14 @@ jobs:
         run: |
           ct lint --all --chart-dirs . --config ./ct/lint-cfg.yaml --lint-conf ./ct/lint-rules.yaml
 
-      - name: Publish Chart
+      - name: Package chart
         run: |
-          helm package -d ${{ github.workspace }}/main-chart ./helm/botkube --version ${{ steps.process-chart.outputs.chart_version }}
-          helm repo index --url "${{ env.CHART_REPOSITORY }}" --merge ${{ github.workspace }}/main-chart/index.yaml ${{ github.workspace }}/main-chart/
+          mkdir -p "${{ github.workspace }}/main-chart"
+          helm package -d "${{ github.workspace }}/main-chart" ./helm/botkube --version ${{ steps.process-chart.outputs.chart_version }}
 
-      - name: GCP auth
-        uses: "google-github-actions/auth@v3"
-        with:
-          credentials_json: ${{ secrets.PLUGINS_BUCKET_CREDENTIALS }}
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v3"
-
-      - name: Upload chart to GCS
-        uses: google-github-actions/upload-cloud-storage@v3
-        with:
-          path: ${{ github.workspace }}/main-chart
-          destination: "botkube-latest-main-charts/"
-          parent: false
+      - name: Push chart to GHCR (OCI)
+        run: |
+          helm push "${{ github.workspace }}/main-chart/botkube-${{ steps.process-chart.outputs.chart_version }}.tgz" "${{ env.CHART_OCI_REPO }}"

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -19,15 +19,16 @@ jobs:
     name: Process Chart Updates
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Update Chart Version in YAML Files
         id: process-chart
         run: |
           CHART_VERSION="0.0.0-$(git rev-parse --short HEAD)"
-          HELM_FOLDER="${{ github.workspace }}/helm"
+          HELM_FOLDER="${GITHUB_WORKSPACE}/helm"
           CHART_CURRENT_VERSION=$(sed -nE 's/^version\s*:\s*([^\s\/]*).*/\1/p' "${HELM_FOLDER}/botkube/Chart.yaml")
           CHART_DEV_VERSION="v9.99.9-dev"
           find "${HELM_FOLDER}" -name "*.yaml" -exec sed -i "s/${CHART_CURRENT_VERSION}/${CHART_VERSION}/g" {} +
@@ -36,7 +37,7 @@ jobs:
           echo "chart_version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Run chart-testing
         working-directory: ${{ github.workspace }}/helm
@@ -44,13 +45,22 @@ jobs:
           ct lint --all --chart-dirs . --config ./ct/lint-cfg.yaml --lint-conf ./ct/lint-rules.yaml
 
       - name: Package chart
+        env:
+          CHART_VERSION: ${{ steps.process-chart.outputs.chart_version }}
         run: |
-          mkdir -p "${{ github.workspace }}/main-chart"
-          helm package -d "${{ github.workspace }}/main-chart" ./helm/botkube --version ${{ steps.process-chart.outputs.chart_version }}
+          mkdir -p "${GITHUB_WORKSPACE}/main-chart"
+          helm package -d "${GITHUB_WORKSPACE}/main-chart" ./helm/botkube --version "${CHART_VERSION}"
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+        env:
+          GH_USER: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${GH_TOKEN}" | helm registry login ghcr.io -u "${GH_USER}" --password-stdin
 
       - name: Push chart to GHCR (OCI)
+        env:
+          CHART_VERSION: ${{ steps.process-chart.outputs.chart_version }}
+          OCI_REPO: ${{ env.CHART_OCI_REPO }}
         run: |
-          helm push "${{ github.workspace }}/main-chart/botkube-${{ steps.process-chart.outputs.chart_version }}.tgz" "${{ env.CHART_OCI_REPO }}"
+          helm push "${GITHUB_WORKSPACE}/main-chart/botkube-${CHART_VERSION}.tgz" "${OCI_REPO}"

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -19,7 +19,7 @@ jobs:
     name: Process Chart Updates
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -17,6 +17,11 @@ DISABLE_ERRORS_LINTERS:
   - REPOSITORY_CHECKOV
   - REPOSITORY_DEVSKIM
 
+# zizmor needs to call the GitHub API to perform the ref-confusion audit;
+# without GITHUB_TOKEN it gets 401-rate-limited and fails the whole job.
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
+  - GITHUB_TOKEN
+
 FLAVOR_SUGGESTIONS: false
 
 REPOSITORY_TRIVY_ARGUMENTS: "--ignorefile .megalinter/.trivyignore --skip-dirs examples --skip-dirs megalinter-reports"

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -17,7 +17,7 @@ prepare() {
 
 release_snapshot() {
 	prepare
-	goreleaser release --clean --snapshot --skip-publish
+	goreleaser release --clean --snapshot --skip=publish
 
 	# Push images
 	docker push "${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${GORELEASER_CURRENT_TAG}"-amd64
@@ -59,7 +59,7 @@ save_images() {
 	export GORELEASER_CURRENT_TAG=${IMAGE_TAG}
 
 	GORELEASER_FILE="$(prepare_goreleaser)"
-	goreleaser release --clean --snapshot --skip-publish --config="${GORELEASER_FILE}"
+	goreleaser release --clean --snapshot --skip=publish --config="${GORELEASER_FILE}"
 
 	mkdir -p "${IMAGE_SAVE_LOAD_DIR}"
 
@@ -144,7 +144,7 @@ build() {
 		-e GORELEASER_CURRENT_TAG=v9.99.9-dev \
 		-e ANALYTICS_API_KEY="${ANALYTICS_API_KEY}" \
 		-e CLI_ANALYTICS_API_KEY="${CLI_ANALYTICS_API_KEY}" \
-		goreleaser/goreleaser release --clean --snapshot --skip-publish
+		goreleaser/goreleaser release --clean --snapshot --skip=publish
 }
 
 build_plugins_command() {


### PR DESCRIPTION
Two failures on  after #217 merged:

**1.  →  step**

GoReleaser v2 renamed the flag to . Updated all 3 invocations in .

**2.  → **
Workflow tried to authenticate to a kubeshop-owned GCS bucket using , which doesn't exist in this fork.

Replaced GCS publish with **OCI push to GHCR** under  using the auto-provided  (no extra secrets needed). Aligns with the broader move to GHCR-only artifacts.