### PR TITLE
ci(dockerfile): drop stale openssh=~9.3 pin

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source="git@github.com:kubeshop/botkube.git" \
 
 COPY botkube-agent /usr/local/bin/botkube-agent
 
-RUN apk add --no-cache 'git=>2.38' 'openssh=~9.3' && \
+RUN apk add --no-cache git openssh && \
     mkdir /root/.ssh && \
     chmod 700 /root/.ssh && \
     ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
After fixing goreleaser config in #219,  got 14 minutes in before failing on docker build:



Alpine 3.23 ships openssh 10.x; the  constraint is stale. Same goes for  (alpine has had ≥2.38 for years). Drop both — re-pinning every alpine bump isn't worth it.