### PR TITLE
feat: add feature to create/update Slack Canvas

### DIFF
--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -400,6 +400,29 @@ func run(ctx context.Context) (err error) {
 	actionProvider := action.NewProvider(logger.WithField(componentLogFieldKey, "Action Provider"), conf.Actions, executorFactory)
 
 	sourcePluginDispatcher := source.NewDispatcher(logger, conf.Settings.ClusterName, bots, sinkNotifiers, pluginManager, actionProvider, analyticsReporter, auditReporter, kubeConfig)
+
+	if conf.Settings.StatusCanvas.Enabled {
+		canvasClient, err := statusCanvasClient(bots)
+		if err != nil {
+			logger.Warnf("Status canvas is enabled but no usable Slack bot was found: %s", err.Error())
+		} else {
+			statusCollector, err := status.NewCollector(logger.WithField(componentLogFieldKey, "Status Canvas Collector"), k8sCli, conf.Settings.StatusCanvas)
+			if err != nil {
+				return reportFatalError("while creating status canvas collector", err)
+			}
+
+			clusterState := status.NewClusterState(conf.Settings.ClusterName, conf.Settings.StatusCanvas.Sections.Warnings.Limit)
+			statusObserver := status.NewObserver(logger.WithField(componentLogFieldKey, "Status Canvas Observer"), clusterState, conf.Settings.StatusCanvas)
+			sourcePluginDispatcher = sourcePluginDispatcher.WithStateObserver(statusObserver)
+
+			statusPublisher := status.NewPublisher(logger.WithField(componentLogFieldKey, "Status Canvas Publisher"), conf.Settings.StatusCanvas, canvasClient, statusCollector, clusterState)
+			errGroup.Go(func() error {
+				defer analytics.ReportPanicIfOccurs(logger, analyticsReporter)
+				return statusPublisher.Start(ctx)
+			})
+		}
+	}
+
 	scheduler := source.NewScheduler(ctx, logger, conf, sourcePluginDispatcher, schedulerChan)
 	err = scheduler.Start(ctx)
 	if err != nil {
@@ -511,6 +534,20 @@ func getK8sClients(cfg *rest.Config) (dynamic.Interface, discovery.DiscoveryInte
 
 	discoCacheClient := memory.NewMemCacheClient(discoveryClient)
 	return dynamicK8sCli, discoCacheClient, nil
+}
+
+// statusCanvasClient picks a Socket Slack bot to drive the status canvas.
+//
+// Botkube Cloud no longer exists, so only Socket Mode Slack (with its own token and canvases:write
+// scope) can host a channel canvas. Selection is stable across restarts by sorting the keys, so the
+// canvas does not jump between bots as configuration changes elsewhere.
+func statusCanvasClient(bots map[string]bot.Bot) (status.CanvasClient, error) {
+	for _, key := range maputil.SortKeys(bots) {
+		if socketSlack, ok := bots[key].(*bot.SocketSlack); ok {
+			return socketSlack.Client(), nil
+		}
+	}
+	return nil, errors.New("no Socket Slack bot is configured")
 }
 
 func reportFatalErrFn(logger logrus.FieldLogger, reporter analytics.Reporter, status status.StatusReporter) func(ctx string, err error) error {

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -52,25 +52,25 @@ A virtual SRE, powered by AI.
 | [sources.k8s-recommendation-events.botkube/kubernetes](./values.yaml#L138) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [executors.k8s-default-tools.botkubeExtra/helm.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L143) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.k8s-default-tools.botkubeExtra/helm.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L145) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [executors.k8s-default-tools.botkubeExtra/helm.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L148) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations](./values.yaml#L162) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod](./values.yaml#L164) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod.noLatestImageTag](./values.yaml#L166) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
@@ -84,9 +84,9 @@ A virtual SRE, powered by AI.
 | [sources.k8s-all-events.botkube/kubernetes.config.filters.nodeEventsChecker](./values.yaml#L190) | bool | `true` | If true, filters out Node-related events that are not important. |
 | [sources.k8s-all-events.botkube/kubernetes.config.namespaces](./values.yaml#L194) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L198) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
-| [sources.k8s-create-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L198) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
-| [sources.k8s-err-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L198) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-all-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L198) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-err-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L198) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-create-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L198) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event](./values.yaml#L208) | object | `{"message":{"exclude":[],"include":[]},"reason":{"exclude":[],"include":[]},"types":["create","delete","error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event.types](./values.yaml#L210) | list | `["create","delete","error"]` | Lists all event types to be watched. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event.reason](./values.yaml#L216) | object | `{"exclude":[],"include":[]}` | Optional list of exact values or regex patterns to filter events by event reason. Skipped, if both include/exclude lists are empty. |
@@ -166,58 +166,74 @@ A virtual SRE, powered by AI.
 | [settings.log.formatter](./values.yaml#L694) | string | `"json"` | Configures log format. Allowed values: `text`, `json`. |
 | [settings.systemConfigMap](./values.yaml#L697) | object | `{"name":"botkube-system"}` | Botkube's system ConfigMap where internal data is stored. |
 | [settings.persistentConfig](./values.yaml#L702) | object | `{"runtime":{"configMap":{"annotations":{},"name":"botkube-runtime-config"},"fileName":"_runtime_state.yaml"},"startup":{"configMap":{"annotations":{},"name":"botkube-startup-config"},"fileName":"_startup_state.yaml"}}` | Persistent config contains ConfigMap where persisted configuration is stored. The persistent configuration is evaluated from both chart upgrade and Botkube commands used in runtime. |
-| [ssl.enabled](./values.yaml#L717) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
-| [ssl.existingSecretName](./values.yaml#L723) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
-| [ssl.cert](./values.yaml#L726) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
-| [service](./values.yaml#L729) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
-| [serviceMonitor](./values.yaml#L736) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
-| [deployment.annotations](./values.yaml#L746) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
-| [deployment.livenessProbe](./values.yaml#L748) | object | `{"failureThreshold":35,"initialDelaySeconds":1,"periodSeconds":2,"successThreshold":1,"timeoutSeconds":1}` | Liveness probe. |
-| [deployment.livenessProbe.initialDelaySeconds](./values.yaml#L750) | int | `1` | The liveness probe initial delay seconds. |
-| [deployment.livenessProbe.periodSeconds](./values.yaml#L752) | int | `2` | The liveness probe period seconds. |
-| [deployment.livenessProbe.timeoutSeconds](./values.yaml#L754) | int | `1` | The liveness probe timeout seconds. |
-| [deployment.livenessProbe.failureThreshold](./values.yaml#L756) | int | `35` | The liveness probe failure threshold. |
-| [deployment.livenessProbe.successThreshold](./values.yaml#L758) | int | `1` | The liveness probe success threshold. |
-| [deployment.readinessProbe](./values.yaml#L761) | object | `{"failureThreshold":35,"initialDelaySeconds":1,"periodSeconds":2,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe. |
-| [deployment.readinessProbe.initialDelaySeconds](./values.yaml#L763) | int | `1` | The readiness probe initial delay seconds. |
-| [deployment.readinessProbe.periodSeconds](./values.yaml#L765) | int | `2` | The readiness probe period seconds. |
-| [deployment.readinessProbe.timeoutSeconds](./values.yaml#L767) | int | `1` | The readiness probe timeout seconds. |
-| [deployment.readinessProbe.failureThreshold](./values.yaml#L769) | int | `35` | The readiness probe failure threshold. |
-| [deployment.readinessProbe.successThreshold](./values.yaml#L771) | int | `1` | The readiness probe success threshold. |
-| [extraAnnotations](./values.yaml#L778) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
-| [extraLabels](./values.yaml#L780) | object | `{}` | Extra labels to pass to the Botkube Pod. |
-| [priorityClassName](./values.yaml#L782) | string | `""` | Priority class name for the Botkube Pod. |
-| [nameOverride](./values.yaml#L785) | string | `""` | Fully override "botkube.name" template. |
-| [fullnameOverride](./values.yaml#L787) | string | `""` | Fully override "botkube.fullname" template. |
-| [resources](./values.yaml#L793) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| [extraEnv](./values.yaml#L805) | list | `[{"name":"LOG_LEVEL_SOURCE_BOTKUBE_KUBERNETES","value":"debug"}]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
-| [extraVolumes](./values.yaml#L818) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
-| [extraVolumeMounts](./values.yaml#L833) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
-| [nodeSelector](./values.yaml#L851) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). |
-| [tolerations](./values.yaml#L855) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
-| [affinity](./values.yaml#L859) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
-| [serviceAccount.create](./values.yaml#L863) | bool | `true` | If true, a ServiceAccount is automatically created. |
-| [serviceAccount.name](./values.yaml#L866) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
-| [serviceAccount.annotations](./values.yaml#L868) | object | `{}` | Extra annotations for the ServiceAccount. |
-| [extraObjects](./values.yaml#L871) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
-| [analytics.disable](./values.yaml#L898) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see the [Privacy Policy](https://botkube.io/privacy-policy). |
-| [configWatcher](./values.yaml#L902) | object | `{"enabled":true,"inCluster":{"informerResyncPeriod":"10m"}}` | Parameters for the Config Watcher component which reloads Botkube on ConfigMap changes. It restarts Botkube when configuration data change is detected. It watches ConfigMaps and/or Secrets with the `botkube.io/config-watch: "true"` label from the namespace where Botkube is installed. |
-| [configWatcher.enabled](./values.yaml#L904) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
-| [configWatcher.inCluster](./values.yaml#L906) | object | `{"informerResyncPeriod":"10m"}` | In-cluster Config Watcher configuration. It is used when remote configuration is not provided. |
-| [configWatcher.inCluster.informerResyncPeriod](./values.yaml#L908) | string | `"10m"` | Resync period for the Config Watcher informers. |
-| [plugins](./values.yaml#L911) | object | `{"cacheDir":"/tmp","healthCheckInterval":"10s","incomingWebhook":{"enabled":true,"port":2115,"targetPort":2115},"repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v1.14.0/plugins-index.yaml"},"botkubeExtra":{"url":"https://github.com/kubeshop/botkube-plugins/releases/download/v1.14.0/plugins-index.yaml"}},"restartPolicy":{"threshold":10,"type":"DeactivatePlugin"}}` | Configuration for Botkube executors and sources plugins. |
-| [plugins.cacheDir](./values.yaml#L913) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
-| [plugins.repositories](./values.yaml#L915) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v1.14.0/plugins-index.yaml"},"botkubeExtra":{"url":"https://github.com/kubeshop/botkube-plugins/releases/download/v1.14.0/plugins-index.yaml"}}` | List of plugins repositories. Each repository defines the URL and optional `headers` |
-| [plugins.repositories.botkube](./values.yaml#L917) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v1.14.0/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [plugins.incomingWebhook](./values.yaml#L924) | object | `{"enabled":true,"port":2115,"targetPort":2115}` | Configure Incoming webhook for source plugins. |
-| [plugins.restartPolicy](./values.yaml#L929) | object | `{"threshold":10,"type":"DeactivatePlugin"}` | Botkube Restart Policy on plugin failure. |
-| [plugins.restartPolicy.type](./values.yaml#L931) | string | `"DeactivatePlugin"` | Restart policy type. Allowed values: "RestartAgent", "DeactivatePlugin". |
-| [plugins.restartPolicy.threshold](./values.yaml#L933) | int | `10` | Number of restarts before policy takes into effect. |
-| [config](./values.yaml#L937) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
-| [config.provider](./values.yaml#L939) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
-| [config.provider.identifier](./values.yaml#L942) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
-| [config.provider.endpoint](./values.yaml#L944) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
-| [config.provider.apiKey](./values.yaml#L946) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
+| [settings.statusCanvas.enabled](./values.yaml#L719) | bool | `false` | If true, keeps a Slack channel canvas up to date with the cluster status. |
+| [settings.statusCanvas.channels](./values.yaml#L721) | list | `[]` | Slack channels to maintain a status canvas in. Each channel gets its own canvas tab. |
+| [settings.statusCanvas.title](./values.yaml#L723) | string | `"{{ .ClusterName }} cluster status"` | Canvas title. Supports the `{{ .ClusterName }}` template variable. |
+| [settings.statusCanvas.updateInterval](./values.yaml#L725) | string | `"10s"` | How often to check for changes and republish the canvas if needed. |
+| [settings.statusCanvas.snapshotInterval](./values.yaml#L727) | string | `"5m"` | How often to fully re-list the cluster, independent of events. |
+| [settings.statusCanvas.namespaces](./values.yaml#L729) | object | `{"exclude":[],"include":[".*"]}` | Namespaces to include or exclude from the canvas. Uses the same regex matching as source namespace filters. |
+| [settings.statusCanvas.sections.summary](./values.yaml#L735) | object | `{"disabled":false}` | Cluster-wide summary counts. |
+| [settings.statusCanvas.sections.nodes](./values.yaml#L738) | object | `{"disabled":false,"limit":25}` | Node health table. |
+| [settings.statusCanvas.sections.nodes.limit](./values.yaml#L741) | int | `25` | Maximum number of nodes to show. 0 means unlimited. |
+| [settings.statusCanvas.sections.workloads](./values.yaml#L743) | object | `{"disabled":false,"limit":25}` | Unhealthy workloads table. |
+| [settings.statusCanvas.sections.workloads.limit](./values.yaml#L746) | int | `25` | Maximum number of workloads to show. 0 means unlimited. |
+| [settings.statusCanvas.sections.catalog](./values.yaml#L748) | object | `{"disabled":false,"labelSelector":"botkube.io/canvas=true","limit":50}` | Opt-in service catalog showing workload versions and rollout status. |
+| [settings.statusCanvas.sections.catalog.limit](./values.yaml#L751) | int | `50` | Maximum number of catalog entries to show. 0 means unlimited. |
+| [settings.statusCanvas.sections.catalog.labelSelector](./values.yaml#L753) | string | `"botkube.io/canvas=true"` | Label selector for workloads to include in the catalog. |
+| [settings.statusCanvas.sections.warnings](./values.yaml#L755) | object | `{"disabled":false,"limit":15}` | Recent Kubernetes warning events. |
+| [settings.statusCanvas.sections.warnings.limit](./values.yaml#L758) | int | `15` | Maximum number of warnings to show. 0 means unlimited. |
+| [ssl.enabled](./values.yaml#L763) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
+| [ssl.existingSecretName](./values.yaml#L769) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
+| [ssl.cert](./values.yaml#L772) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
+| [service](./values.yaml#L775) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
+| [serviceMonitor](./values.yaml#L782) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
+| [deployment.annotations](./values.yaml#L792) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
+| [deployment.livenessProbe](./values.yaml#L794) | object | `{"failureThreshold":35,"initialDelaySeconds":1,"periodSeconds":2,"successThreshold":1,"timeoutSeconds":1}` | Liveness probe. |
+| [deployment.livenessProbe.initialDelaySeconds](./values.yaml#L796) | int | `1` | The liveness probe initial delay seconds. |
+| [deployment.livenessProbe.periodSeconds](./values.yaml#L798) | int | `2` | The liveness probe period seconds. |
+| [deployment.livenessProbe.timeoutSeconds](./values.yaml#L800) | int | `1` | The liveness probe timeout seconds. |
+| [deployment.livenessProbe.failureThreshold](./values.yaml#L802) | int | `35` | The liveness probe failure threshold. |
+| [deployment.livenessProbe.successThreshold](./values.yaml#L804) | int | `1` | The liveness probe success threshold. |
+| [deployment.readinessProbe](./values.yaml#L807) | object | `{"failureThreshold":35,"initialDelaySeconds":1,"periodSeconds":2,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe. |
+| [deployment.readinessProbe.initialDelaySeconds](./values.yaml#L809) | int | `1` | The readiness probe initial delay seconds. |
+| [deployment.readinessProbe.periodSeconds](./values.yaml#L811) | int | `2` | The readiness probe period seconds. |
+| [deployment.readinessProbe.timeoutSeconds](./values.yaml#L813) | int | `1` | The readiness probe timeout seconds. |
+| [deployment.readinessProbe.failureThreshold](./values.yaml#L815) | int | `35` | The readiness probe failure threshold. |
+| [deployment.readinessProbe.successThreshold](./values.yaml#L817) | int | `1` | The readiness probe success threshold. |
+| [extraAnnotations](./values.yaml#L824) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
+| [extraLabels](./values.yaml#L826) | object | `{}` | Extra labels to pass to the Botkube Pod. |
+| [priorityClassName](./values.yaml#L828) | string | `""` | Priority class name for the Botkube Pod. |
+| [nameOverride](./values.yaml#L831) | string | `""` | Fully override "botkube.name" template. |
+| [fullnameOverride](./values.yaml#L833) | string | `""` | Fully override "botkube.fullname" template. |
+| [resources](./values.yaml#L839) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| [extraEnv](./values.yaml#L851) | list | `[{"name":"LOG_LEVEL_SOURCE_BOTKUBE_KUBERNETES","value":"debug"}]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
+| [extraVolumes](./values.yaml#L864) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
+| [extraVolumeMounts](./values.yaml#L879) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
+| [nodeSelector](./values.yaml#L897) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). |
+| [tolerations](./values.yaml#L901) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
+| [affinity](./values.yaml#L905) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
+| [serviceAccount.create](./values.yaml#L909) | bool | `true` | If true, a ServiceAccount is automatically created. |
+| [serviceAccount.name](./values.yaml#L912) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
+| [serviceAccount.annotations](./values.yaml#L914) | object | `{}` | Extra annotations for the ServiceAccount. |
+| [extraObjects](./values.yaml#L917) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
+| [analytics.disable](./values.yaml#L944) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see the [Privacy Policy](https://botkube.io/privacy-policy). |
+| [configWatcher](./values.yaml#L948) | object | `{"enabled":true,"inCluster":{"informerResyncPeriod":"10m"}}` | Parameters for the Config Watcher component which reloads Botkube on ConfigMap changes. It restarts Botkube when configuration data change is detected. It watches ConfigMaps and/or Secrets with the `botkube.io/config-watch: "true"` label from the namespace where Botkube is installed. |
+| [configWatcher.enabled](./values.yaml#L950) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
+| [configWatcher.inCluster](./values.yaml#L952) | object | `{"informerResyncPeriod":"10m"}` | In-cluster Config Watcher configuration. It is used when remote configuration is not provided. |
+| [configWatcher.inCluster.informerResyncPeriod](./values.yaml#L954) | string | `"10m"` | Resync period for the Config Watcher informers. |
+| [plugins](./values.yaml#L957) | object | `{"cacheDir":"/tmp","healthCheckInterval":"10s","incomingWebhook":{"enabled":true,"port":2115,"targetPort":2115},"repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v1.14.0/plugins-index.yaml"},"botkubeExtra":{"url":"https://github.com/kubeshop/botkube-plugins/releases/download/v1.14.0/plugins-index.yaml"}},"restartPolicy":{"threshold":10,"type":"DeactivatePlugin"}}` | Configuration for Botkube executors and sources plugins. |
+| [plugins.cacheDir](./values.yaml#L959) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
+| [plugins.repositories](./values.yaml#L961) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v1.14.0/plugins-index.yaml"},"botkubeExtra":{"url":"https://github.com/kubeshop/botkube-plugins/releases/download/v1.14.0/plugins-index.yaml"}}` | List of plugins repositories. Each repository defines the URL and optional `headers` |
+| [plugins.repositories.botkube](./values.yaml#L963) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v1.14.0/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
+| [plugins.incomingWebhook](./values.yaml#L970) | object | `{"enabled":true,"port":2115,"targetPort":2115}` | Configure Incoming webhook for source plugins. |
+| [plugins.restartPolicy](./values.yaml#L975) | object | `{"threshold":10,"type":"DeactivatePlugin"}` | Botkube Restart Policy on plugin failure. |
+| [plugins.restartPolicy.type](./values.yaml#L977) | string | `"DeactivatePlugin"` | Restart policy type. Allowed values: "RestartAgent", "DeactivatePlugin". |
+| [plugins.restartPolicy.threshold](./values.yaml#L979) | int | `10` | Number of restarts before policy takes into effect. |
+| [config](./values.yaml#L983) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
+| [config.provider](./values.yaml#L985) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
+| [config.provider.identifier](./values.yaml#L988) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
+| [config.provider.endpoint](./values.yaml#L990) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
+| [config.provider.apiKey](./values.yaml#L992) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/templates/clusterrole.yaml
+++ b/helm/botkube/templates/clusterrole.yaml
@@ -27,4 +27,17 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "users", "groups", "serviceaccounts" ]
     verbs: [ "impersonate" ]
+{{- if .Values.settings.statusCanvas.enabled }}
+  {{- /*
+    The cluster status canvas snapshots cluster state directly, so it needs read access to the
+    resources it renders. These are granted only when the canvas is enabled, to avoid widening
+    Botkube's permissions for deployments that do not use it.
+  */}}
+  - apiGroups: [ "" ]
+    resources: [ "namespaces", "pods", "events" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "apps" ]
+    resources: [ "deployments", "statefulsets", "daemonsets" ]
+    verbs: [ "get", "list" ]
+{{- end }}
   {{- end }}

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -711,6 +711,52 @@ settings:
         annotations: {}
       fileName: "_runtime_state.yaml"
 
+  ## Slack channel canvas that mirrors the current cluster status. Requires a Socket Mode Slack bot
+  ## with the `canvases:write` scope. The canvas is rewritten in full on every update, so manual
+  ## edits made in Slack are overwritten.
+  statusCanvas:
+    # -- If true, keeps a Slack channel canvas up to date with the cluster status.
+    enabled: false
+    # -- Slack channels to maintain a status canvas in. Each channel gets its own canvas tab.
+    channels: []
+    # -- Canvas title. Supports the `{{ .ClusterName }}` template variable.
+    title: "{{ .ClusterName }} cluster status"
+    # -- How often to check for changes and republish the canvas if needed.
+    updateInterval: "10s"
+    # -- How often to fully re-list the cluster, independent of events.
+    snapshotInterval: "5m"
+    # -- Namespaces to include or exclude from the canvas. Uses the same regex matching as source namespace filters.
+    namespaces:
+      include:
+        - ".*"
+      exclude: []
+    sections:
+      # -- Cluster-wide summary counts.
+      summary:
+        disabled: false
+      # -- Node health table.
+      nodes:
+        disabled: false
+        # -- Maximum number of nodes to show. 0 means unlimited.
+        limit: 25
+      # -- Unhealthy workloads table.
+      workloads:
+        disabled: false
+        # -- Maximum number of workloads to show. 0 means unlimited.
+        limit: 25
+      # -- Opt-in service catalog showing workload versions and rollout status.
+      catalog:
+        disabled: false
+        # -- Maximum number of catalog entries to show. 0 means unlimited.
+        limit: 50
+        # -- Label selector for workloads to include in the catalog.
+        labelSelector: "botkube.io/canvas=true"
+      # -- Recent Kubernetes warning events.
+      warnings:
+        disabled: false
+        # -- Maximum number of warnings to show. 0 means unlimited.
+        limit: 15
+
 ## For using custom SSL certificates.
 ssl:
   # -- If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`.

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -35,6 +36,15 @@ type Dispatcher struct {
 	sinkNotifiers        []notifier.Sink
 	restCfg              *rest.Config
 	clusterName          string
+	stateObserver        StateObserver
+}
+
+// StateObserver observes dispatched events to maintain a derived view of the cluster state.
+// It is optional: when nil, events are dispatched exactly as before.
+type StateObserver interface {
+	// ObserveEvent is called for every dispatched event. Implementations must not block, as this
+	// runs on the event delivery path.
+	ObserveEvent(pluginName string, rawObject any)
 }
 
 // ActionProvider defines a provider that is responsible for automated actions.
@@ -85,6 +95,31 @@ func NewDispatcher(log logrus.FieldLogger, clusterName string, notifiers map[str
 		restCfg:              restCfg,
 		clusterName:          clusterName,
 	}
+}
+
+// WithStateObserver sets the observer notified about every dispatched event.
+func (d *Dispatcher) WithStateObserver(observer StateObserver) *Dispatcher {
+	d.stateObserver = observer
+	return d
+}
+
+// observeEvent hands the event to the state observer, if one is configured.
+//
+// The observer maintains an accessory view of the cluster, so a bug in it must not stop event
+// delivery. Unlike the notifier goroutines, which report a panic as a fatal app error, a panic here
+// is logged and swallowed: losing the status canvas is preferable to losing notifications.
+func (d *Dispatcher) observeEvent(pluginName string, rawObject any) {
+	if d.stateObserver == nil {
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			d.log.Errorf("recovered from panic while observing event for %q: %v\n%s", pluginName, r, string(debug.Stack()))
+		}
+	}()
+
+	d.stateObserver.ObserveEvent(pluginName, rawObject)
 }
 
 // Dispatch starts a given plugin, watches for incoming events and calling all notifiers to dispatch received event.
@@ -187,6 +222,8 @@ func (d *Dispatcher) dispatchMsg(ctx context.Context, event source.Event, dispat
 		pluginName = dispatch.pluginName
 		sources    = []string{dispatch.sourceName}
 	)
+
+	d.observeEvent(pluginName, event.RawObject)
 
 	for _, n := range d.getBotNotifiers(dispatch) {
 		go func(n notifier.Bot) {

--- a/internal/source/dispatcher_test.go
+++ b/internal/source/dispatcher_test.go
@@ -1,0 +1,58 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/iggy/botkube/pkg/loggerx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingObserver struct {
+	pluginNames []string
+	rawObjects  []any
+	panics      bool
+}
+
+func (o *recordingObserver) ObserveEvent(pluginName string, rawObject any) {
+	o.pluginNames = append(o.pluginNames, pluginName)
+	o.rawObjects = append(o.rawObjects, rawObject)
+	if o.panics {
+		panic("boom")
+	}
+}
+
+func TestObserveEventWithoutObserver(t *testing.T) {
+	// The observer is optional, so a dispatcher without one must behave exactly as before.
+	dispatcher := NewDispatcher(loggerx.NewNoop(), "test", nil, nil, nil, nil, nil, nil, nil)
+
+	assert.NotPanics(t, func() {
+		dispatcher.observeEvent("botkube/kubernetes", map[string]any{"Kind": "Pod"})
+	})
+}
+
+func TestObserveEventForwardsToObserver(t *testing.T) {
+	// given
+	observer := &recordingObserver{}
+	dispatcher := NewDispatcher(loggerx.NewNoop(), "test", nil, nil, nil, nil, nil, nil, nil).WithStateObserver(observer)
+	event := map[string]any{"Kind": "Pod", "Name": "api-1"}
+
+	// when
+	dispatcher.observeEvent("botkube/kubernetes", event)
+
+	// then
+	require.Equal(t, []string{"botkube/kubernetes"}, observer.pluginNames)
+	assert.Equal(t, []any{event}, observer.rawObjects)
+}
+
+func TestObserveEventSurvivesPanickingObserver(t *testing.T) {
+	// The observer maintains an accessory view of the cluster. A panic in it must be contained here,
+	// because the caller goes on to deliver the event to every notifier.
+	observer := &recordingObserver{panics: true}
+	dispatcher := NewDispatcher(loggerx.NewNoop(), "test", nil, nil, nil, nil, nil, nil, nil).WithStateObserver(observer)
+
+	assert.NotPanics(t, func() {
+		dispatcher.observeEvent("botkube/kubernetes", map[string]any{"Kind": "Pod"})
+	})
+	assert.Len(t, observer.pluginNames, 1)
+}

--- a/internal/status/canvas.go
+++ b/internal/status/canvas.go
@@ -1,0 +1,165 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/slack-go/slack"
+
+	"github.com/iggy/botkube/pkg/conversation"
+)
+
+// CanvasClient is the narrow slice of the Slack API the status canvas needs.
+//
+// Keeping it an interface rather than taking *slack.Client directly lets the publisher be tested
+// without a Slack server, and documents exactly which four calls this feature makes.
+type CanvasClient interface {
+	// GetConversationInfoContext resolves channel metadata, including any existing channel canvas.
+	GetConversationInfoContext(ctx context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error)
+
+	// GetConversationsContext lists channels, used to resolve configured channel names to IDs.
+	GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) ([]slack.Channel, string, error)
+
+	// CreateChannelCanvasContext creates a channel canvas.
+	CreateChannelCanvasContext(ctx context.Context, channel string, documentContent slack.DocumentContent, options ...slack.CreateChannelCanvasOption) (string, error)
+
+	// EditCanvasContext applies changes to an existing canvas.
+	EditCanvasContext(ctx context.Context, params slack.EditCanvasParams) error
+}
+
+// Slack errors that mean the workspace cannot host a Botkube status canvas at all. These are
+// configuration problems, not transient failures, so the publisher reports them and gives up on the
+// channel rather than retrying forever.
+var fatalCanvasErrors = map[string]string{
+	"team_tier_cannot_create_channel_canvases": "the Slack workspace plan does not allow creating channel canvases",
+	"canvas_disabled_user_team":                "canvases are disabled for the Slack workspace",
+	"canvases_disabled_user_team":              "canvases are disabled for the Slack workspace",
+	"missing_scope":                            "the Slack bot token is missing the 'canvases:write' scope",
+	"not_allowed_token_type":                   "the Slack token type cannot manage canvases",
+}
+
+// Slack errors that mean the canvas already exists. Botkube then adopts the existing canvas instead
+// of failing: creating and adopting are the same intent, and on free plans only one canvas tab per
+// channel is permitted.
+var canvasExistsErrors = map[string]struct{}{
+	"channel_canvas_already_exists":       {},
+	"free_team_canvas_tab_already_exists": {},
+}
+
+// slackErrorCode extracts the Slack API error code from err.
+//
+// Canvas methods return a SlackErrorResponse carrying the code, but the code can also arrive as a
+// plain error when it comes from a wrapped or synthesized failure, so both are handled.
+func slackErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var slackErr slack.SlackErrorResponse
+	if errors.As(err, &slackErr) {
+		return slackErr.Err
+	}
+	return err.Error()
+}
+
+// fatalCanvasError returns a descriptive error when err is one Botkube cannot recover from.
+func fatalCanvasError(err error) error {
+	if reason, ok := fatalCanvasErrors[slackErrorCode(err)]; ok {
+		return fmt.Errorf("%s (Slack error %q)", reason, slackErrorCode(err))
+	}
+	return nil
+}
+
+// isCanvasExistsError reports whether err means the channel already has a canvas.
+func isCanvasExistsError(err error) bool {
+	_, ok := canvasExistsErrors[slackErrorCode(err)]
+	return ok
+}
+
+// channelResolver maps configured channel names or IDs to Slack channel IDs.
+//
+// Resolved IDs are cached because channel IDs are stable for the lifetime of a channel, and the
+// alternative would be paging conversations.list on every debounce tick.
+type channelResolver struct {
+	client CanvasClient
+	cache  map[string]string
+}
+
+func newChannelResolver(client CanvasClient) *channelResolver {
+	return &channelResolver{client: client, cache: map[string]string{}}
+}
+
+// maxConversationPages bounds paging through conversations.list so an enormous workspace cannot
+// stall startup indefinitely.
+const maxConversationPages = 20
+
+// Resolve returns the channel ID for the given configured channel reference.
+func (r *channelResolver) Resolve(ctx context.Context, channel string) (string, error) {
+	name, _ := conversation.NormalizeChannelIdentifier(channel)
+	if name == "" {
+		return "", errors.New("channel must not be empty")
+	}
+
+	if id, ok := r.cache[name]; ok {
+		return id, nil
+	}
+
+	// A Slack channel ID is usable directly. Names cannot start with C/G/D and be all-caps, so
+	// trying conversations.info first is unambiguous and costs one call instead of paging the list.
+	if looksLikeChannelID(name) {
+		info, err := r.client.GetConversationInfoContext(ctx, &slack.GetConversationInfoInput{ChannelID: name})
+		if err == nil && info != nil {
+			r.cache[name] = info.ID
+			return info.ID, nil
+		}
+	}
+
+	var cursor string
+	for range maxConversationPages {
+		channels, next, err := r.client.GetConversationsContext(ctx, &slack.GetConversationsParameters{
+			Cursor:          cursor,
+			Limit:           200,
+			ExcludeArchived: true,
+			Types:           []string{"public_channel", "private_channel"},
+		})
+		if err != nil {
+			return "", fmt.Errorf("while listing Slack conversations: %w", err)
+		}
+
+		for _, ch := range channels {
+			// Cache every channel seen; a later lookup for a different configured channel is then free.
+			if _, ok := r.cache[ch.Name]; !ok {
+				r.cache[ch.Name] = ch.ID
+			}
+			if ch.Name == name || ch.ID == name {
+				r.cache[name] = ch.ID
+				return ch.ID, nil
+			}
+		}
+
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+
+	return "", fmt.Errorf("channel %q not found; make sure Botkube is invited to it", channel)
+}
+
+// looksLikeChannelID reports whether the value is shaped like a Slack conversation ID.
+func looksLikeChannelID(in string) bool {
+	if len(in) < 9 {
+		return false
+	}
+
+	switch in[0] {
+	case 'C', 'G', 'D':
+	default:
+		return false
+	}
+
+	// IDs are uppercase alphanumeric; channel names are lowercase, so any lowercase rules it out.
+	return in == strings.ToUpper(in)
+}

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -1,0 +1,578 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/iggy/botkube/pkg/config"
+	"github.com/iggy/botkube/pkg/multierror"
+)
+
+// Collector builds a full cluster snapshot by listing resources directly.
+//
+// Listing rather than watching is deliberate: the canvas renders a whole-cluster view that is
+// rewritten in full on every update, so a point-in-time list is exactly the shape needed. It also
+// makes the snapshot self-correcting, since it never depends on having seen every intermediate event.
+type Collector struct {
+	k8sCli kubernetes.Interface
+	log    logrus.FieldLogger
+	cfg    config.StatusCanvas
+
+	// catalogSelector is the pre-validated label selector for the opt-in service catalog.
+	catalogSelector string
+}
+
+// NewCollector returns a Collector for the given configuration.
+func NewCollector(log logrus.FieldLogger, k8sCli kubernetes.Interface, cfg config.StatusCanvas) (*Collector, error) {
+	selector := strings.TrimSpace(cfg.Sections.Catalog.LabelSelector)
+	if selector != "" {
+		// Fail at construction rather than on every collection pass, so a typo surfaces at startup.
+		if _, err := metav1.ParseToLabelSelector(selector); err != nil {
+			return nil, fmt.Errorf("while parsing status canvas catalog label selector %q: %w", selector, err)
+		}
+	}
+
+	return &Collector{
+		k8sCli:          k8sCli,
+		log:             log,
+		cfg:             cfg,
+		catalogSelector: selector,
+	}, nil
+}
+
+// Collect gathers a full cluster snapshot.
+//
+// A failure in one section does not abandon the whole snapshot: a canvas showing four of five
+// sections plus a logged error is more useful than no update at all. Errors are aggregated and
+// returned so the caller can log them, while the returned data holds whatever did succeed.
+func (c *Collector) Collect(ctx context.Context) (SnapshotData, error) {
+	var (
+		out    SnapshotData
+		errs   = multierror.New()
+		podsNS = map[string][]corev1.Pod{}
+	)
+
+	if version, err := c.k8sCli.Discovery().ServerVersion(); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("while getting server version: %w", err))
+	} else {
+		out.Summary.KubernetesVer = version.GitVersion
+	}
+
+	namespaces, err := c.namespacesInScope(ctx)
+	if err != nil {
+		// Without the namespace scope every namespaced lookup below would be unscoped, which could
+		// leak resources the operator excluded on purpose. Bail out instead.
+		return out, fmt.Errorf("while resolving namespaces in scope: %w", err)
+	}
+	out.Summary.NamespacesInScope = len(namespaces)
+
+	nodes, err := c.collectNodes(ctx)
+	if err != nil {
+		errs = multierror.Append(errs, err)
+	} else {
+		out.Nodes = nodes
+		out.Summary.NodesTotal = len(nodes)
+		for _, n := range nodes {
+			if n.Health == HealthOK {
+				out.Summary.NodesReady++
+			}
+		}
+	}
+
+	for _, ns := range namespaces {
+		pods, err := c.k8sCli.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing pods in namespace %q: %w", ns, err))
+			continue
+		}
+		podsNS[ns] = pods.Items
+		out.Summary.PodsTotal += len(pods.Items)
+	}
+
+	workloads, total, err := c.collectWorkloads(ctx, namespaces, podsNS)
+	if err != nil {
+		errs = multierror.Append(errs, err)
+	}
+	out.Workloads = workloads
+	out.Summary.WorkloadsTotal = total
+	for _, w := range workloads {
+		if w.Kind == "Pod" {
+			out.Summary.PodsUnhealthy++
+		}
+	}
+
+	if !c.cfg.Sections.Catalog.Disabled {
+		catalog, err := c.collectCatalog(ctx, namespaces, podsNS)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		out.Catalog = catalog
+	}
+
+	if !c.cfg.Sections.Warnings.Disabled {
+		warnings, err := c.collectWarnings(ctx, namespaces)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		out.Warnings = warnings
+	}
+
+	return out, errs.ErrorOrNil()
+}
+
+// namespacesInScope lists namespaces allowed by the configured include/exclude constraints.
+func (c *Collector) namespacesInScope(ctx context.Context) ([]string, error) {
+	list, err := c.k8sCli.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("while listing namespaces: %w", err)
+	}
+
+	constraints := c.cfg.Namespaces
+	// An unconfigured namespace list means the whole cluster. Without this, RegexConstraints with an
+	// empty Include would reject everything and the canvas would silently render empty.
+	allowAll := !constraints.AreConstraintsDefined()
+
+	var out []string
+	for _, ns := range list.Items {
+		if allowAll {
+			out = append(out, ns.Name)
+			continue
+		}
+
+		allowed, err := constraints.IsAllowed(ns.Name)
+		if err != nil {
+			return nil, fmt.Errorf("while matching namespace %q: %w", ns.Name, err)
+		}
+		if allowed {
+			out = append(out, ns.Name)
+		}
+	}
+
+	sort.Strings(out)
+	return out, nil
+}
+
+func (c *Collector) collectNodes(ctx context.Context) ([]Node, error) {
+	if c.cfg.Sections.Nodes.Disabled && c.cfg.Sections.Summary.Disabled {
+		return nil, nil
+	}
+
+	list, err := c.k8sCli.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("while listing nodes: %w", err)
+	}
+
+	out := make([]Node, 0, len(list.Items))
+	for _, node := range list.Items {
+		entry := Node{
+			Name:        node.Name,
+			Schedulable: !node.Spec.Unschedulable,
+			KubeletVer:  node.Status.NodeInfo.KubeletVersion,
+			Health:      HealthUnknown,
+			Ready:       string(corev1.ConditionUnknown),
+		}
+
+		for _, cond := range node.Status.Conditions {
+			if cond.Type != corev1.NodeReady {
+				continue
+			}
+
+			entry.Ready = string(cond.Status)
+			switch cond.Status {
+			case corev1.ConditionTrue:
+				entry.Health = HealthOK
+			case corev1.ConditionFalse:
+				entry.Health = HealthFailing
+				entry.Reason = cond.Reason
+			default:
+				// A node reporting Unknown has stopped heartbeating; its workloads are at risk even
+				// though the node has not been declared NotReady, so treat it as failing.
+				entry.Health = HealthFailing
+				entry.Reason = cond.Reason
+			}
+			break
+		}
+
+		// A cordoned node is not broken, but it cannot take new work, which is worth surfacing.
+		if entry.Health == HealthOK && !entry.Schedulable {
+			entry.Health = HealthDegraded
+			entry.Reason = "unschedulable"
+		}
+
+		out = append(out, entry)
+	}
+
+	return out, nil
+}
+
+// collectWorkloads returns workloads and pods which are not in their desired state, along with the
+// total number of workloads inspected. Healthy entries are intentionally dropped: the section exists
+// to show what needs attention, and keeping them would bury the signal.
+func (c *Collector) collectWorkloads(ctx context.Context, namespaces []string, podsNS map[string][]corev1.Pod) ([]Workload, int, error) {
+	if c.cfg.Sections.Workloads.Disabled && c.cfg.Sections.Summary.Disabled {
+		return nil, 0, nil
+	}
+
+	var (
+		out   []Workload
+		total int
+		errs  = multierror.New()
+	)
+
+	for _, ns := range namespaces {
+		deployments, err := c.k8sCli.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing deployments in namespace %q: %w", ns, err))
+		} else {
+			total += len(deployments.Items)
+			for _, d := range deployments.Items {
+				desired := int32(1)
+				if d.Spec.Replicas != nil {
+					desired = *d.Spec.Replicas
+				}
+				if entry, ok := replicaWorkload("Deployment", ns, d.Name, d.Status.ReadyReplicas, desired); ok {
+					out = append(out, entry)
+				}
+			}
+		}
+
+		statefulSets, err := c.k8sCli.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing statefulsets in namespace %q: %w", ns, err))
+		} else {
+			total += len(statefulSets.Items)
+			for _, s := range statefulSets.Items {
+				desired := int32(1)
+				if s.Spec.Replicas != nil {
+					desired = *s.Spec.Replicas
+				}
+				if entry, ok := replicaWorkload("StatefulSet", ns, s.Name, s.Status.ReadyReplicas, desired); ok {
+					out = append(out, entry)
+				}
+			}
+		}
+
+		daemonSets, err := c.k8sCli.AppsV1().DaemonSets(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing daemonsets in namespace %q: %w", ns, err))
+		} else {
+			total += len(daemonSets.Items)
+			for _, d := range daemonSets.Items {
+				// DaemonSets have no replica spec; the scheduler decides how many are wanted.
+				desired := d.Status.DesiredNumberScheduled
+				if entry, ok := replicaWorkload("DaemonSet", ns, d.Name, d.Status.NumberReady, desired); ok {
+					out = append(out, entry)
+				}
+			}
+		}
+
+		for _, pod := range podsNS[ns] {
+			if entry, ok := unhealthyPod(pod); ok {
+				out = append(out, entry)
+			}
+		}
+	}
+
+	return out, total, errs.ErrorOrNil()
+}
+
+// replicaWorkload reports a replica-based workload when it is below its desired count.
+func replicaWorkload(kind, namespace, name string, ready, desired int32) (Workload, bool) {
+	if ready >= desired {
+		return Workload{}, false
+	}
+
+	// Zero ready replicas means the workload serves nothing; a partial rollout still serves traffic.
+	health := HealthDegraded
+	if ready == 0 && desired > 0 {
+		health = HealthFailing
+	}
+
+	return Workload{
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+		Health:    health,
+		Ready:     ready,
+		Desired:   desired,
+		Reason:    fmt.Sprintf("%d/%d ready", ready, desired),
+	}, true
+}
+
+// unhealthyPod reports a pod which is not running normally.
+func unhealthyPod(pod corev1.Pod) (Workload, bool) {
+	// Succeeded pods are completed Jobs, not failures, so they are not reported.
+	if pod.Status.Phase == corev1.PodSucceeded {
+		return Workload{}, false
+	}
+
+	var (
+		restarts   int32
+		reason     string
+		health     = HealthOK
+		ready      int32
+		containers = int32(len(pod.Status.ContainerStatuses))
+	)
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.RestartCount > restarts {
+			restarts = cs.RestartCount
+		}
+		if cs.Ready {
+			ready++
+		}
+		if cs.State.Waiting != nil && reason == "" {
+			reason = cs.State.Waiting.Reason
+			// CrashLoopBackOff and ImagePullBackOff mean the container cannot start at all.
+			health = HealthFailing
+		}
+	}
+
+	switch pod.Status.Phase {
+	case corev1.PodFailed:
+		health = HealthFailing
+		if reason == "" {
+			reason = pod.Status.Reason
+		}
+	case corev1.PodPending:
+		if health == HealthOK {
+			health = HealthDegraded
+			if reason == "" {
+				reason = "Pending"
+			}
+		}
+	case corev1.PodRunning:
+		// A Running pod with containers not yet ready is mid-startup or failing readiness.
+		if health == HealthOK && containers > 0 && ready < containers {
+			health = HealthDegraded
+			if reason == "" {
+				reason = "containers not ready"
+			}
+		}
+	}
+
+	if health == HealthOK {
+		return Workload{}, false
+	}
+	if reason == "" {
+		reason = string(pod.Status.Phase)
+	}
+
+	return Workload{
+		Kind:      "Pod",
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+		Health:    health,
+		Ready:     ready,
+		Desired:   containers,
+		Reason:    reason,
+		Restarts:  restarts,
+	}, true
+}
+
+// collectCatalog builds the opt-in service catalog. Only workloads matching the configured label
+// selector are included, which keeps the section a curated catalog instead of a cluster dump.
+func (c *Collector) collectCatalog(ctx context.Context, namespaces []string, podsNS map[string][]corev1.Pod) ([]CatalogEntry, error) {
+	var (
+		out  []CatalogEntry
+		errs = multierror.New()
+		opts = metav1.ListOptions{LabelSelector: c.catalogSelector}
+	)
+
+	for _, ns := range namespaces {
+		deployments, err := c.k8sCli.AppsV1().Deployments(ns).List(ctx, opts)
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing catalog deployments in namespace %q: %w", ns, err))
+		} else {
+			for _, d := range deployments.Items {
+				desired := int32(1)
+				if d.Spec.Replicas != nil {
+					desired = *d.Spec.Replicas
+				}
+				out = append(out, c.catalogEntry("Deployment", ns, d.Name, d.Spec.Selector, d.Spec.Template, d.Status.ReadyReplicas, desired, podsNS[ns]))
+			}
+		}
+
+		statefulSets, err := c.k8sCli.AppsV1().StatefulSets(ns).List(ctx, opts)
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing catalog statefulsets in namespace %q: %w", ns, err))
+		} else {
+			for _, s := range statefulSets.Items {
+				desired := int32(1)
+				if s.Spec.Replicas != nil {
+					desired = *s.Spec.Replicas
+				}
+				out = append(out, c.catalogEntry("StatefulSet", ns, s.Name, s.Spec.Selector, s.Spec.Template, s.Status.ReadyReplicas, desired, podsNS[ns]))
+			}
+		}
+
+		daemonSets, err := c.k8sCli.AppsV1().DaemonSets(ns).List(ctx, opts)
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing catalog daemonsets in namespace %q: %w", ns, err))
+		} else {
+			for _, d := range daemonSets.Items {
+				out = append(out, c.catalogEntry("DaemonSet", ns, d.Name, d.Spec.Selector, d.Spec.Template, d.Status.NumberReady, d.Status.DesiredNumberScheduled, podsNS[ns]))
+			}
+		}
+	}
+
+	return out, errs.ErrorOrNil()
+}
+
+// catalogEntry describes one catalog workload: the image versions it declares plus whether the
+// running pods have actually converged on them.
+func (c *Collector) catalogEntry(kind, namespace, name string, selector *metav1.LabelSelector, template corev1.PodTemplateSpec, ready, desired int32, pods []corev1.Pod) CatalogEntry {
+	entry := CatalogEntry{
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+		Ready:     ready,
+		Desired:   desired,
+		Health:    HealthOK,
+	}
+
+	for _, container := range template.Spec.Containers {
+		entry.Images = append(entry.Images, ContainerImage{
+			Container: container.Name,
+			Image:     container.Image,
+			Version:   imageVersion(container.Image),
+		})
+	}
+
+	// The spec says which image is wanted; the pods say which images are actually live. If the pods
+	// disagree with the spec, or with each other, the rollout has not finished.
+	live := liveImages(selector, template, pods)
+	for _, container := range entry.Images {
+		versions := live[container.Container]
+		if len(versions) > 1 {
+			entry.RollingOut = true
+			break
+		}
+		if len(versions) == 1 && !versions[container.Image] {
+			entry.RollingOut = true
+			break
+		}
+	}
+
+	if ready < desired {
+		entry.Health = HealthDegraded
+		if ready == 0 && desired > 0 {
+			entry.Health = HealthFailing
+		}
+	}
+
+	return entry
+}
+
+// liveImages maps container name to the set of images that container is running across the
+// workload's pods.
+func liveImages(selector *metav1.LabelSelector, template corev1.PodTemplateSpec, pods []corev1.Pod) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+
+	match, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil || match == nil || match.Empty() {
+		// Without a usable selector the workload's pods cannot be identified. Reporting no live
+		// images simply leaves RollingOut false rather than guessing from unrelated pods.
+		return out
+	}
+
+	for _, pod := range pods {
+		if !match.Matches(labels.Set(pod.Labels)) {
+			continue
+		}
+
+		for _, container := range pod.Spec.Containers {
+			if out[container.Name] == nil {
+				out[container.Name] = map[string]bool{}
+			}
+			out[container.Name][container.Image] = true
+		}
+	}
+
+	// Containers absent from the template are sidecars injected by a mutating webhook; they would
+	// otherwise show up as spurious rollout signal.
+	declared := map[string]bool{}
+	for _, container := range template.Spec.Containers {
+		declared[container.Name] = true
+	}
+	for name := range out {
+		if !declared[name] {
+			delete(out, name)
+		}
+	}
+
+	return out
+}
+
+func (c *Collector) collectWarnings(ctx context.Context, namespaces []string) ([]Warning, error) {
+	var (
+		out  []Warning
+		errs = multierror.New()
+		// Only Warning-type events are rendered, so filter server-side rather than fetching
+		// every Normal event just to discard it.
+		opts = metav1.ListOptions{FieldSelector: "type=Warning"}
+	)
+
+	for _, ns := range namespaces {
+		list, err := c.k8sCli.CoreV1().Events(ns).List(ctx, opts)
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while listing warning events in namespace %q: %w", ns, err))
+			continue
+		}
+
+		for _, event := range list.Items {
+			out = append(out, Warning{
+				Namespace: event.Namespace,
+				Kind:      event.InvolvedObject.Kind,
+				Name:      event.InvolvedObject.Name,
+				Reason:    event.Reason,
+				Message:   event.Message,
+				Count:     event.Count,
+				Timestamp: eventTimestamp(event),
+			})
+		}
+	}
+
+	return out, errs.ErrorOrNil()
+}
+
+// eventTimestamp picks the most recent timestamp an event carries. Which fields are populated
+// depends on how the event was emitted, so all three are checked.
+func eventTimestamp(event corev1.Event) time.Time {
+	if !event.LastTimestamp.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	if !event.EventTime.IsZero() {
+		return event.EventTime.Time
+	}
+	return event.CreationTimestamp.Time
+}
+
+// imageVersion extracts the human-readable version from an image reference.
+func imageVersion(image string) string {
+	// A digest-pinned reference has no meaningful tag; show a short digest instead.
+	if idx := strings.LastIndex(image, "@"); idx != -1 {
+		digest := image[idx+1:]
+		if short := strings.TrimPrefix(digest, "sha256:"); short != digest && len(short) > 12 {
+			return "sha256:" + short[:12]
+		}
+		return digest
+	}
+
+	// The last colon is only a tag separator if it comes after the last slash; otherwise it is the
+	// port of a registry host such as registry.local:5000/app.
+	idx := strings.LastIndex(image, ":")
+	if idx == -1 || idx < strings.LastIndex(image, "/") {
+		return "latest"
+	}
+	return image[idx+1:]
+}

--- a/internal/status/collector_test.go
+++ b/internal/status/collector_test.go
@@ -1,0 +1,421 @@
+package status
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/iggy/botkube/pkg/config"
+	"github.com/iggy/botkube/pkg/loggerx"
+	"github.com/iggy/botkube/pkg/ptr"
+)
+
+func namespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func readyNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			NodeInfo:   corev1.NodeSystemInfo{KubeletVersion: "v1.34.2"},
+		},
+	}
+}
+
+func TestCollectorNamespaceScope(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces config.RegexConstraints
+		expected   int
+	}{
+		{
+			// An unconfigured namespace list must mean "everything". RegexConstraints with an empty
+			// Include rejects every value, which would silently render an empty canvas.
+			name:     "no constraints means all namespaces",
+			expected: 3,
+		},
+		{
+			name:       "include regex",
+			namespaces: config.RegexConstraints{Include: []string{"app-.*"}},
+			expected:   2,
+		},
+		{
+			name:       "exclude wins over include",
+			namespaces: config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"kube-system"}},
+			expected:   2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			k8sCli := fake.NewSimpleClientset(namespace("app-one"), namespace("app-two"), namespace("kube-system"))
+			cfg := config.StatusCanvas{Namespaces: tc.namespaces}
+			collector, err := NewCollector(loggerx.NewNoop(), k8sCli, cfg)
+			require.NoError(t, err)
+
+			// when
+			out, err := collector.Collect(context.Background())
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, out.Summary.NamespacesInScope)
+		})
+	}
+}
+
+func TestCollectorNodeHealth(t *testing.T) {
+	// given
+	notReady := readyNode("node-bad")
+	notReady.Status.Conditions = []corev1.NodeCondition{{
+		Type: corev1.NodeReady, Status: corev1.ConditionFalse, Reason: "KubeletNotReady",
+	}}
+
+	cordoned := readyNode("node-cordoned")
+	cordoned.Spec.Unschedulable = true
+
+	unknown := readyNode("node-unknown")
+	unknown.Status.Conditions = []corev1.NodeCondition{{
+		Type: corev1.NodeReady, Status: corev1.ConditionUnknown, Reason: "NodeStatusUnknown",
+	}}
+
+	k8sCli := fake.NewSimpleClientset(readyNode("node-ok"), notReady, cordoned, unknown)
+	collector, err := NewCollector(loggerx.NewNoop(), k8sCli, config.StatusCanvas{})
+	require.NoError(t, err)
+
+	// when
+	out, err := collector.Collect(context.Background())
+
+	// then
+	require.NoError(t, err)
+	byName := map[string]Node{}
+	for _, n := range out.Nodes {
+		byName[n.Name] = n
+	}
+
+	assert.Equal(t, HealthOK, byName["node-ok"].Health)
+	assert.Equal(t, HealthFailing, byName["node-bad"].Health)
+	// A cordoned node still serves traffic, so it is degraded rather than failing.
+	assert.Equal(t, HealthDegraded, byName["node-cordoned"].Health)
+	assert.Equal(t, "unschedulable", byName["node-cordoned"].Reason)
+	// A node that stopped heartbeating puts its workloads at risk, so Unknown counts as failing.
+	assert.Equal(t, HealthFailing, byName["node-unknown"].Health)
+
+	assert.Equal(t, 4, out.Summary.NodesTotal)
+	assert.Equal(t, 1, out.Summary.NodesReady)
+}
+
+func TestCollectorReportsOnlyUnhealthyWorkloads(t *testing.T) {
+	// given
+	healthy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "healthy", Namespace: "app"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr.FromType[int32](2)},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 2},
+	}
+	degraded := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "degraded", Namespace: "app"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr.FromType[int32](3)},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+	down := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "down", Namespace: "app"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: ptr.FromType[int32](2)},
+		Status:     appsv1.StatefulSetStatus{ReadyReplicas: 0},
+	}
+
+	k8sCli := fake.NewSimpleClientset(namespace("app"), healthy, degraded, down)
+	collector, err := NewCollector(loggerx.NewNoop(), k8sCli, config.StatusCanvas{})
+	require.NoError(t, err)
+
+	// when
+	out, err := collector.Collect(context.Background())
+
+	// then
+	require.NoError(t, err)
+
+	byName := map[string]Workload{}
+	for _, w := range out.Workloads {
+		byName[w.Name] = w
+	}
+
+	assert.NotContains(t, byName, "healthy", "healthy workloads would bury the ones needing attention")
+	assert.Equal(t, HealthDegraded, byName["degraded"].Health)
+	// Zero ready replicas means the workload serves nothing, which is worse than a partial rollout.
+	assert.Equal(t, HealthFailing, byName["down"].Health)
+	assert.Equal(t, 3, out.Summary.WorkloadsTotal, "all workloads are counted, not just unhealthy ones")
+}
+
+func TestUnhealthyPod(t *testing.T) {
+	tests := []struct {
+		name           string
+		pod            corev1.Pod
+		expectReported bool
+		expectedHealth Health
+		expectedReason string
+	}{
+		{
+			name: "running and ready is not reported",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase:             corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+				},
+			},
+		},
+		{
+			// A completed Job is not a failure; reporting it would fill the section with noise.
+			name: "succeeded is not reported",
+			pod:  corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}},
+		},
+		{
+			name: "crash looping is failing",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						RestartCount: 5,
+						State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+					}},
+				},
+			},
+			expectReported: true,
+			expectedHealth: HealthFailing,
+			expectedReason: "CrashLoopBackOff",
+		},
+		{
+			name:           "failed phase is failing",
+			pod:            corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed, Reason: "Evicted"}},
+			expectReported: true,
+			expectedHealth: HealthFailing,
+			expectedReason: "Evicted",
+		},
+		{
+			name:           "pending is degraded",
+			pod:            corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
+			expectReported: true,
+			expectedHealth: HealthDegraded,
+			expectedReason: "Pending",
+		},
+		{
+			name: "running but not ready is degraded",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase:             corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{Ready: true}, {Ready: false}},
+				},
+			},
+			expectReported: true,
+			expectedHealth: HealthDegraded,
+			expectedReason: "containers not ready",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, reported := unhealthyPod(tc.pod)
+
+			require.Equal(t, tc.expectReported, reported)
+			if !tc.expectReported {
+				return
+			}
+			assert.Equal(t, tc.expectedHealth, out.Health)
+			assert.Equal(t, tc.expectedReason, out.Reason)
+		})
+	}
+}
+
+func TestCollectorCatalogIsOptIn(t *testing.T) {
+	// given
+	labelled := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "listed",
+			Namespace: "app",
+			Labels:    map[string]string{"botkube.io/canvas": "true"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.FromType[int32](1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "listed"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "listed"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "api", Image: "ghcr.io/acme/api:1.2.3"}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+	unlabelled := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "hidden", Namespace: "app"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr.FromType[int32](1)},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+
+	k8sCli := fake.NewSimpleClientset(namespace("app"), labelled, unlabelled)
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Catalog.LabelSelector = "botkube.io/canvas=true"
+	collector, err := NewCollector(loggerx.NewNoop(), k8sCli, cfg)
+	require.NoError(t, err)
+
+	// when
+	out, err := collector.Collect(context.Background())
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, out.Catalog, 1, "only labelled workloads belong in a curated catalog")
+	assert.Equal(t, "listed", out.Catalog[0].Name)
+	require.Len(t, out.Catalog[0].Images, 1)
+	assert.Equal(t, "1.2.3", out.Catalog[0].Images[0].Version)
+}
+
+func TestCollectorDetectsRollout(t *testing.T) {
+	// A rollout is in progress when the live pods disagree with each other about the image, which the
+	// workload's own status cannot express.
+	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
+	podLabels := map[string]string{"app": "web"}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "app",
+			Labels: map[string]string{"botkube.io/canvas": "true"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.FromType[int32](2),
+			Selector: selector,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web", Image: "acme/web:2.0.0"}}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 2},
+	}
+
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-old", Namespace: "app", Labels: podLabels},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web", Image: "acme/web:1.0.0"}}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+		},
+	}
+	newPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-new", Namespace: "app", Labels: podLabels},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web", Image: "acme/web:2.0.0"}}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+		},
+	}
+
+	k8sCli := fake.NewSimpleClientset(namespace("app"), deployment, oldPod, newPod)
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Catalog.LabelSelector = "botkube.io/canvas=true"
+	collector, err := NewCollector(loggerx.NewNoop(), k8sCli, cfg)
+	require.NoError(t, err)
+
+	// when
+	out, err := collector.Collect(context.Background())
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, out.Catalog, 1)
+	assert.True(t, out.Catalog[0].RollingOut, "two live image versions mean the rollout has not settled")
+}
+
+func TestCollectorIgnoresInjectedSidecarsForRollout(t *testing.T) {
+	// A mutating webhook can add containers absent from the template. Counting them would report a
+	// permanent rollout that never settles.
+	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
+	podLabels := map[string]string{"app": "web"}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web", Namespace: "app",
+			Labels: map[string]string{"botkube.io/canvas": "true"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.FromType[int32](1),
+			Selector: selector,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web", Image: "acme/web:2.0.0"}}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "app", Labels: podLabels},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "web", Image: "acme/web:2.0.0"},
+			{Name: "istio-proxy", Image: "istio/proxyv2:1.20.0"},
+		}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: true}, {Ready: true}},
+		},
+	}
+
+	k8sCli := fake.NewSimpleClientset(namespace("app"), deployment, pod)
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Catalog.LabelSelector = "botkube.io/canvas=true"
+	collector, err := NewCollector(loggerx.NewNoop(), k8sCli, cfg)
+	require.NoError(t, err)
+
+	// when
+	out, err := collector.Collect(context.Background())
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, out.Catalog, 1)
+	assert.False(t, out.Catalog[0].RollingOut)
+}
+
+func TestNewCollectorRejectsInvalidLabelSelector(t *testing.T) {
+	// Failing at construction surfaces a typo at startup instead of on every collection pass.
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Catalog.LabelSelector = "!!! not a selector"
+
+	_, err := NewCollector(loggerx.NewNoop(), fake.NewSimpleClientset(), cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "catalog label selector")
+}
+
+func TestImageVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		{name: "simple tag", image: "nginx:1.25", expected: "1.25"},
+		{name: "registry with tag", image: "ghcr.io/acme/api:1.4.2", expected: "1.4.2"},
+		{name: "no tag defaults to latest", image: "nginx", expected: "latest"},
+		{name: "registry path without tag", image: "ghcr.io/acme/api", expected: "latest"},
+		{
+			// The colon here is a registry port, not a tag separator.
+			name:     "registry port without tag",
+			image:    "registry.local:5000/acme/api",
+			expected: "latest",
+		},
+		{name: "registry port with tag", image: "registry.local:5000/acme/api:3.1", expected: "3.1"},
+		{
+			name:     "digest is truncated",
+			image:    "acme/api@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			expected: "sha256:0123456789ab",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, imageVersion(tc.image))
+		})
+	}
+}

--- a/internal/status/observer.go
+++ b/internal/status/observer.go
@@ -1,0 +1,197 @@
+package status
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/iggy/botkube/pkg/config"
+)
+
+// kubernetesPluginName is the plugin whose events describe cluster state.
+const kubernetesPluginName = "kubernetes"
+
+// Observer applies Kubernetes source plugin events to the cluster state, so the canvas reacts to
+// changes without waiting for the next full snapshot.
+//
+// What an event can contribute is limited by the plugin boundary. Source events are serialized to
+// JSON before reaching the agent, and the Kubernetes source event type excludes the underlying
+// object from that JSON. Events therefore carry identity, reason and message, but no object status.
+// The consequence is a split:
+//
+//   - Warnings need only what the event already carries, so they are applied directly.
+//   - Nodes, workloads and the catalog need replica counts, conditions and images, so the event can
+//     only flag those sections stale. The publisher then asks the collector for fresh data.
+//
+// The alternative, inferring status from an event's reason string, would put guessed data on the
+// canvas; marking stale keeps the collector the single source of truth for anything status-shaped.
+type Observer struct {
+	log   logrus.FieldLogger
+	state *ClusterState
+	cfg   config.StatusCanvas
+}
+
+// NewObserver returns an Observer feeding the given cluster state.
+func NewObserver(log logrus.FieldLogger, state *ClusterState, cfg config.StatusCanvas) *Observer {
+	return &Observer{log: log, state: state, cfg: cfg}
+}
+
+// pluginEvent mirrors the subset of the Kubernetes source event that survives JSON serialization.
+// It is decoded structurally rather than by importing the source plugin's event type, which would
+// couple the agent to a plugin's internals.
+type pluginEvent struct {
+	Kind      string   `json:"Kind"`
+	Name      string   `json:"Name"`
+	Namespace string   `json:"Namespace"`
+	Type      string   `json:"Type"`
+	Reason    string   `json:"Reason"`
+	Level     string   `json:"Level"`
+	Messages  []string `json:"Messages"`
+	Count     int32    `json:"Count"`
+	TimeStamp string   `json:"TimeStamp"`
+	Resource  string   `json:"Resource"`
+}
+
+// ObserveEvent applies a single source plugin event to the cluster state.
+//
+// It never blocks and never fails the caller: the dispatcher calls this on the hot path of event
+// delivery, and a canvas update must not interfere with sending notifications.
+func (o *Observer) ObserveEvent(pluginName string, rawObject any) {
+	if !o.handles(pluginName) {
+		return
+	}
+
+	event, ok := o.decode(rawObject)
+	if !ok {
+		return
+	}
+
+	// Warning-level events are fully described by the event itself.
+	if !o.cfg.Sections.Warnings.Disabled && isWarning(event) {
+		if allowed := o.namespaceAllowed(event.Namespace); allowed {
+			o.state.AddWarning(Warning{
+				Namespace: event.Namespace,
+				Kind:      event.Kind,
+				Name:      event.Name,
+				Reason:    event.Reason,
+				Message:   strings.Join(event.Messages, " "),
+				Count:     event.Count,
+				Timestamp: parseEventTime(event.TimeStamp),
+			})
+		}
+	}
+
+	// Anything else means some object's status may have changed. Flag the sections that render
+	// object status so the publisher re-lists them.
+	o.state.MarkStale(staleSectionsFor(event.Kind)...)
+}
+
+// handles reports whether events from the given plugin describe cluster state.
+func (o *Observer) handles(pluginName string) bool {
+	// pluginName is a full plugin key such as "botkube/kubernetes". Compare the plugin part so a
+	// custom repository name still matches.
+	_, name, _, err := config.DecomposePluginKey(pluginName)
+	if err != nil {
+		// Not a plugin key; fall back to a direct comparison rather than dropping the event.
+		return pluginName == kubernetesPluginName
+	}
+	return name == kubernetesPluginName
+}
+
+// decode converts the dispatcher's raw event into the fields the canvas can use.
+func (o *Observer) decode(rawObject any) (pluginEvent, bool) {
+	// The dispatcher hands over whatever the plugin sent. Round-tripping through JSON handles both
+	// the decoded map from a real plugin and a typed struct from an in-process caller.
+	raw, err := json.Marshal(rawObject)
+	if err != nil {
+		o.log.WithError(err).Debug("Skipping status canvas event that could not be marshalled")
+		return pluginEvent{}, false
+	}
+
+	var event pluginEvent
+	if err := json.Unmarshal(raw, &event); err != nil {
+		o.log.WithError(err).Debug("Skipping status canvas event that could not be decoded")
+		return pluginEvent{}, false
+	}
+
+	// An event with no object identity cannot be attributed to anything renderable.
+	if event.Kind == "" && event.Name == "" {
+		return pluginEvent{}, false
+	}
+
+	return event, true
+}
+
+// namespaceAllowed reports whether the namespace is in the configured scope.
+func (o *Observer) namespaceAllowed(namespace string) bool {
+	// Cluster-scoped objects have no namespace and are always in scope.
+	if namespace == "" {
+		return true
+	}
+
+	constraints := o.cfg.Namespaces
+	if !constraints.AreConstraintsDefined() {
+		return true
+	}
+
+	allowed, err := constraints.IsAllowed(namespace)
+	if err != nil {
+		o.log.WithError(err).Debugf("While matching namespace %q for the status canvas", namespace)
+		return false
+	}
+	return allowed
+}
+
+// isWarning reports whether the event should appear in the warnings section.
+func isWarning(event pluginEvent) bool {
+	// The source plugin maps its event types onto these levels; anything at warn or above is worth
+	// surfacing. The raw Kubernetes event type is also checked, because events read from the Event
+	// API carry "Warning" there rather than in Level.
+	switch {
+	case strings.EqualFold(event.Level, string(config.Warn)),
+		strings.EqualFold(event.Level, string(config.Error)),
+		strings.EqualFold(event.Level, string(config.Critical)),
+		strings.EqualFold(event.Type, "warning"):
+		return true
+	default:
+		return false
+	}
+}
+
+// staleSectionsFor maps an object kind to the canvas sections whose rendering depends on it.
+func staleSectionsFor(kind string) []Section {
+	switch kind {
+	case "Node":
+		return []Section{SectionNodes, SectionSummary}
+	case "Pod":
+		// A pod change can move a workload's ready count and reveal a rollout mid-flight.
+		return []Section{SectionWorkloads, SectionCatalog, SectionSummary}
+	case "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet":
+		return []Section{SectionWorkloads, SectionCatalog, SectionSummary}
+	case "":
+		return nil
+	default:
+		// An unrecognised kind still changes cluster-wide counters.
+		return []Section{SectionSummary}
+	}
+}
+
+// parseEventTime parses the timestamp a source event carries, falling back to now.
+func parseEventTime(in string) time.Time {
+	if in == "" {
+		return time.Now()
+	}
+
+	if ts, err := time.Parse(time.RFC3339Nano, in); err == nil {
+		return ts
+	}
+	if ts, err := time.Parse(time.RFC3339, in); err == nil {
+		return ts
+	}
+
+	// An unparseable timestamp still describes something that just happened, so treating it as now
+	// keeps the warning near the top of the list instead of pinning it to the zero time.
+	return time.Now()
+}

--- a/internal/status/observer_test.go
+++ b/internal/status/observer_test.go
@@ -1,0 +1,207 @@
+package status
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iggy/botkube/pkg/config"
+	"github.com/iggy/botkube/pkg/loggerx"
+)
+
+// sourceEvent mirrors the JSON shape the Kubernetes source plugin sends across the plugin boundary.
+// The observer decodes structurally, so the test feeds it the same map a real plugin would.
+func sourceEvent(kind, name, namespace, level string) map[string]any {
+	return map[string]any{
+		"Kind":      kind,
+		"Name":      name,
+		"Namespace": namespace,
+		"Level":     level,
+		"Reason":    "BackOff",
+		"Messages":  []string{"Back-off restarting failed container"},
+		"Count":     3,
+		"TimeStamp": "2026-08-01T12:30:00Z",
+	}
+}
+
+func TestObserverAppliesWarnings(t *testing.T) {
+	// given
+	state := NewClusterState("test", 10)
+	observer := NewObserver(loggerx.NewNoop(), state, config.StatusCanvas{})
+
+	// when
+	observer.ObserveEvent("botkube/kubernetes", sourceEvent("Pod", "api-1", "shop", string(config.Error)))
+
+	// then
+	warnings := state.Snapshot().Warnings
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "shop", warnings[0].Namespace)
+	assert.Equal(t, "api-1", warnings[0].Name)
+	assert.Equal(t, "BackOff", warnings[0].Reason)
+	assert.Equal(t, "Back-off restarting failed container", warnings[0].Message)
+	assert.Equal(t, int32(3), warnings[0].Count)
+	assert.Equal(t, time.Date(2026, time.August, 1, 12, 30, 0, 0, time.UTC), warnings[0].Timestamp.UTC())
+}
+
+func TestObserverMarksStaleWithoutAddingWarning(t *testing.T) {
+	// An info-level event carries no renderable status across the plugin boundary, so all it can do
+	// is ask for a re-collect.
+	state := NewClusterState("test", 10)
+	observer := NewObserver(loggerx.NewNoop(), state, config.StatusCanvas{})
+
+	observer.ObserveEvent("botkube/kubernetes", sourceEvent("Deployment", "web", "shop", string(config.Info)))
+
+	assert.Empty(t, state.Snapshot().Warnings)
+	assert.Equal(t, []Section{SectionCatalog, SectionSummary, SectionWorkloads}, state.TakeStale())
+}
+
+func TestObserverIgnoresOtherPlugins(t *testing.T) {
+	// Only the Kubernetes source describes cluster state; other sources would corrupt the view.
+	tests := []struct {
+		name       string
+		pluginName string
+		handled    bool
+	}{
+		{name: "full plugin key", pluginName: "botkube/kubernetes", handled: true},
+		{name: "versioned plugin key", pluginName: "botkube/kubernetes@v1.0.0", handled: true},
+		// A custom plugin repository still ships the same plugin.
+		{name: "custom repository", pluginName: "acme/kubernetes", handled: true},
+		{name: "bare plugin name", pluginName: "kubernetes", handled: true},
+		{name: "different plugin", pluginName: "botkube/prometheus", handled: false},
+		{name: "bare other name", pluginName: "argocd", handled: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewClusterState("test", 10)
+			observer := NewObserver(loggerx.NewNoop(), state, config.StatusCanvas{})
+
+			observer.ObserveEvent(tc.pluginName, sourceEvent("Pod", "api-1", "shop", string(config.Error)))
+
+			assert.Len(t, state.Snapshot().Warnings, map[bool]int{true: 1, false: 0}[tc.handled])
+		})
+	}
+}
+
+func TestObserverRespectsNamespaceScope(t *testing.T) {
+	// given
+	state := NewClusterState("test", 10)
+	cfg := config.StatusCanvas{Namespaces: config.RegexConstraints{Include: []string{"shop"}}}
+	observer := NewObserver(loggerx.NewNoop(), state, cfg)
+
+	// when
+	observer.ObserveEvent("botkube/kubernetes", sourceEvent("Pod", "api-1", "shop", string(config.Error)))
+	observer.ObserveEvent("botkube/kubernetes", sourceEvent("Pod", "job-1", "kube-system", string(config.Error)))
+
+	// then
+	warnings := state.Snapshot().Warnings
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "shop", warnings[0].Namespace)
+}
+
+func TestObserverAllowsClusterScopedObjects(t *testing.T) {
+	// A Node has no namespace; filtering it out would hide node failures whenever a namespace scope
+	// is configured.
+	state := NewClusterState("test", 10)
+	cfg := config.StatusCanvas{Namespaces: config.RegexConstraints{Include: []string{"shop"}}}
+	observer := NewObserver(loggerx.NewNoop(), state, cfg)
+
+	observer.ObserveEvent("botkube/kubernetes", sourceEvent("Node", "node-1", "", string(config.Error)))
+
+	assert.Len(t, state.Snapshot().Warnings, 1)
+}
+
+func TestObserverSkipsWarningsWhenSectionDisabled(t *testing.T) {
+	// given
+	state := NewClusterState("test", 10)
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Warnings.Disabled = true
+	observer := NewObserver(loggerx.NewNoop(), state, cfg)
+
+	// when
+	observer.ObserveEvent("botkube/kubernetes", sourceEvent("Pod", "api-1", "shop", string(config.Error)))
+
+	// then
+	assert.Empty(t, state.Snapshot().Warnings)
+	// The other sections still need refreshing; disabling warnings must not disable the whole hook.
+	assert.NotEmpty(t, state.TakeStale())
+}
+
+func TestObserverIgnoresUnidentifiableEvents(t *testing.T) {
+	// given
+	state := NewClusterState("test", 10)
+	observer := NewObserver(loggerx.NewNoop(), state, config.StatusCanvas{})
+	before := state.Revision()
+
+	// when
+	observer.ObserveEvent("botkube/kubernetes", nil)
+	observer.ObserveEvent("botkube/kubernetes", map[string]any{"Level": "error"})
+	// A payload of the wrong shape must be dropped rather than panicking on the delivery hot path.
+	observer.ObserveEvent("botkube/kubernetes", "not an event")
+
+	// then
+	assert.Equal(t, before, state.Revision())
+	assert.Empty(t, state.Snapshot().Warnings)
+	assert.Nil(t, state.TakeStale())
+}
+
+func TestIsWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    pluginEvent
+		expected bool
+	}{
+		{name: "warn level", event: pluginEvent{Level: string(config.Warn)}, expected: true},
+		{name: "error level", event: pluginEvent{Level: string(config.Error)}, expected: true},
+		{name: "critical level", event: pluginEvent{Level: string(config.Critical)}, expected: true},
+		// Events read from the Kubernetes Event API carry the severity in Type, not Level.
+		{name: "raw warning type", event: pluginEvent{Type: "warning"}, expected: true},
+		{name: "mixed case type", event: pluginEvent{Type: "Warning"}, expected: true},
+		{name: "info level", event: pluginEvent{Level: string(config.Info)}, expected: false},
+		{name: "debug level", event: pluginEvent{Level: string(config.Debug)}, expected: false},
+		{name: "nothing set", event: pluginEvent{}, expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isWarning(tc.event))
+		})
+	}
+}
+
+func TestStaleSectionsFor(t *testing.T) {
+	tests := []struct {
+		kind     string
+		expected []Section
+	}{
+		{kind: "Node", expected: []Section{SectionNodes, SectionSummary}},
+		{kind: "Pod", expected: []Section{SectionWorkloads, SectionCatalog, SectionSummary}},
+		{kind: "Deployment", expected: []Section{SectionWorkloads, SectionCatalog, SectionSummary}},
+		{kind: "StatefulSet", expected: []Section{SectionWorkloads, SectionCatalog, SectionSummary}},
+		{kind: "DaemonSet", expected: []Section{SectionWorkloads, SectionCatalog, SectionSummary}},
+		// An unrecognised kind still moves cluster-wide counters, so the summary is refreshed.
+		{kind: "ConfigMap", expected: []Section{SectionSummary}},
+		{kind: "", expected: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.kind, func(t *testing.T) {
+			assert.Equal(t, tc.expected, staleSectionsFor(tc.kind))
+		})
+	}
+}
+
+func TestParseEventTime(t *testing.T) {
+	expected := time.Date(2026, time.August, 1, 12, 30, 0, 0, time.UTC)
+
+	assert.Equal(t, expected, parseEventTime("2026-08-01T12:30:00Z").UTC())
+	assert.Equal(t, expected, parseEventTime("2026-08-01T12:30:00.000000000Z").UTC())
+
+	// An absent or unparseable timestamp still describes something that just happened, so it must not
+	// fall back to the zero time and sink to the bottom of the warnings list.
+	for _, in := range []string{"", "yesterday"} {
+		assert.WithinDuration(t, time.Now(), parseEventTime(in), time.Minute)
+	}
+}

--- a/internal/status/publisher.go
+++ b/internal/status/publisher.go
@@ -1,0 +1,329 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+
+	"github.com/iggy/botkube/pkg/config"
+	"github.com/iggy/botkube/pkg/multierror"
+)
+
+const (
+	defaultUpdateInterval   = 10 * time.Second
+	defaultSnapshotInterval = 5 * time.Minute
+
+	// minUpdateInterval floors the debounce window. canvases.edit is a Tier 3 method, so a very
+	// small window configured by mistake would spend the rate limit budget without adding value.
+	minUpdateInterval = 2 * time.Second
+
+	// canvasMarkdownType is the only document content type canvases accept.
+	canvasMarkdownType = "markdown"
+)
+
+// Publisher keeps one Slack channel canvas per configured channel in sync with the cluster state.
+type Publisher struct {
+	log       logrus.FieldLogger
+	cfg       config.StatusCanvas
+	client    CanvasClient
+	collector *Collector
+	renderer  *Renderer
+	state     *ClusterState
+	resolver  *channelResolver
+
+	// canvasIDs caches the resolved canvas per configured channel.
+	canvasIDs map[string]string
+
+	// disabled records channels Botkube has given up on, so a permanent failure is logged once
+	// rather than on every tick.
+	disabled map[string]struct{}
+
+	// lastPublished is the last body written per channel, used to skip no-op writes.
+	lastPublished map[string]string
+
+	mu sync.Mutex
+}
+
+// NewPublisher returns a Publisher for the given configuration.
+func NewPublisher(log logrus.FieldLogger, cfg config.StatusCanvas, client CanvasClient, collector *Collector, state *ClusterState) *Publisher {
+	return &Publisher{
+		log:           log,
+		cfg:           cfg,
+		client:        client,
+		collector:     collector,
+		renderer:      NewRenderer(cfg),
+		state:         state,
+		resolver:      newChannelResolver(client),
+		canvasIDs:     map[string]string{},
+		disabled:      map[string]struct{}{},
+		lastPublished: map[string]string{},
+	}
+}
+
+// Start collects an initial snapshot, publishes it, and then keeps the canvas up to date until the
+// context is cancelled.
+//
+// Two timers drive it. The update ticker is the debounce window: it publishes only when the state
+// revision moved, so a burst of events produces one canvas write. The snapshot ticker re-lists the
+// cluster, which both picks up changes no event described and corrects any drift.
+func (p *Publisher) Start(ctx context.Context) error {
+	updateInterval := p.cfg.UpdateInterval
+	if updateInterval < minUpdateInterval {
+		if updateInterval > 0 {
+			p.log.Warnf("Status canvas updateInterval %s is below the %s minimum; using the minimum instead.", updateInterval, minUpdateInterval)
+		}
+		updateInterval = max(defaultUpdateInterval, minUpdateInterval)
+	}
+
+	snapshotInterval := p.cfg.SnapshotInterval
+	if snapshotInterval <= 0 {
+		snapshotInterval = defaultSnapshotInterval
+	}
+
+	p.log.WithFields(logrus.Fields{
+		"updateInterval":   updateInterval.String(),
+		"snapshotInterval": snapshotInterval.String(),
+		"channels":         strings.Join(p.cfg.Channels, ","),
+	}).Info("Starting cluster status canvas")
+
+	// Collect and publish immediately so the canvas is correct as soon as Botkube is up, instead of
+	// showing nothing until the first tick.
+	p.collect(ctx)
+	if err := p.publish(ctx); err != nil {
+		// A first-publish failure is logged rather than returned: it is often a missing invite to
+		// one channel, which should not take the whole agent down.
+		p.log.Errorf("while publishing initial cluster status canvas: %s", err)
+	}
+
+	updateTicker := time.NewTicker(updateInterval)
+	defer updateTicker.Stop()
+	snapshotTicker := time.NewTicker(snapshotInterval)
+	defer snapshotTicker.Stop()
+
+	var lastRevision = p.state.Revision()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.log.Info("Shutdown requested. Finishing...")
+			return nil
+
+		case <-snapshotTicker.C:
+			p.collect(ctx)
+
+		case <-updateTicker.C:
+			// Sections flagged by the event path need object status the event could not carry, so
+			// ask the collector for fresh data before rendering.
+			if stale := p.state.TakeStale(); len(stale) > 0 {
+				p.log.WithField("sections", stale).Debug("Re-collecting cluster state for stale sections")
+				p.collect(ctx)
+			}
+
+			revision := p.state.Revision()
+			if revision == lastRevision {
+				continue
+			}
+			lastRevision = revision
+
+			if err := p.publish(ctx); err != nil {
+				p.log.Errorf("while publishing cluster status canvas: %s", err)
+			}
+		}
+	}
+}
+
+// collect runs a full snapshot and applies it to the state.
+func (p *Publisher) collect(ctx context.Context) {
+	data, err := p.collector.Collect(ctx)
+	if err != nil {
+		// Collect returns partial data alongside its error, so the snapshot is still applied: a
+		// canvas missing one section beats a canvas frozen at an older state.
+		p.log.Errorf("while collecting cluster state: %s", err)
+	}
+
+	data.Summary.SnapshotAt = time.Now()
+	p.state.ApplySnapshot(data)
+}
+
+// publish renders the current state and writes it to every configured channel canvas.
+func (p *Publisher) publish(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	body := p.renderer.Render(p.state.Snapshot())
+	errs := multierror.New()
+
+	for _, channel := range p.cfg.Channels {
+		if _, skip := p.disabled[channel]; skip {
+			continue
+		}
+
+		if err := p.publishToChannel(ctx, channel, body); err != nil {
+			// A workspace-level problem such as a plan restriction or a missing scope will never
+			// resolve on its own, so stop retrying that channel and say so once.
+			if fatal := fatalCanvasError(err); fatal != nil {
+				p.disabled[channel] = struct{}{}
+				errs = multierror.Append(errs, fmt.Errorf("status canvas disabled for channel %q: %w", channel, fatal))
+				continue
+			}
+			errs = multierror.Append(errs, fmt.Errorf("while publishing canvas to channel %q: %w", channel, err))
+			continue
+		}
+
+		p.lastPublished[channel] = body
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func (p *Publisher) publishToChannel(ctx context.Context, channel, body string) error {
+	// Rendering is deterministic, so an identical body means the cluster view did not change and
+	// the write would be a no-op that still costs rate limit budget.
+	if p.lastPublished[channel] == body {
+		return nil
+	}
+
+	canvasID, err := p.canvasIDFor(ctx, channel, body)
+	if err != nil {
+		return err
+	}
+
+	// A freshly created canvas already holds this body.
+	if p.lastPublished[channel] == body {
+		return nil
+	}
+
+	// replace without a section_id replaces the whole canvas, which matches the full-rewrite model:
+	// the rendered body is always the complete current state.
+	err = p.client.EditCanvasContext(ctx, slack.EditCanvasParams{
+		CanvasID: canvasID,
+		Changes: []slack.CanvasChange{
+			{
+				Operation: "replace",
+				DocumentContent: slack.DocumentContent{
+					Type:     canvasMarkdownType,
+					Markdown: body,
+				},
+			},
+		},
+	})
+	if err != nil {
+		// The canvas may have been deleted in Slack since it was cached. Drop the cached ID so the
+		// next tick rediscovers or recreates it instead of editing a canvas that is gone.
+		if isCanvasNotFoundError(err) {
+			delete(p.canvasIDs, channel)
+		}
+		return fmt.Errorf("while editing canvas %q: %w", canvasID, err)
+	}
+
+	return nil
+}
+
+// canvasIDFor returns the channel's canvas, adopting an existing one or creating it if absent.
+//
+// No canvas ID is persisted anywhere: a channel canvas is discoverable from the channel itself, so
+// the ID survives restarts without Botkube storing state.
+func (p *Publisher) canvasIDFor(ctx context.Context, channel, body string) (string, error) {
+	if id, ok := p.canvasIDs[channel]; ok {
+		return id, nil
+	}
+
+	channelID, err := p.resolver.Resolve(ctx, channel)
+	if err != nil {
+		return "", err
+	}
+
+	if id, err := p.existingCanvasID(ctx, channelID); err != nil {
+		return "", err
+	} else if id != "" {
+		p.canvasIDs[channel] = id
+		return id, nil
+	}
+
+	title, err := p.canvasTitle()
+	if err != nil {
+		return "", err
+	}
+
+	// Create with the rendered body so a new canvas is never briefly empty.
+	id, err := p.client.CreateChannelCanvasContext(ctx, channelID, slack.DocumentContent{
+		Type:     canvasMarkdownType,
+		Markdown: body,
+	}, slack.CreateChannelCanvasOptionTitle(title))
+	if err != nil {
+		// Losing a create race, or hitting the free-plan one-tab-per-channel limit, both mean a
+		// canvas exists to adopt.
+		if isCanvasExistsError(err) {
+			existing, lookupErr := p.existingCanvasID(ctx, channelID)
+			if lookupErr != nil {
+				return "", fmt.Errorf("while looking up existing canvas after %q: %w", err, lookupErr)
+			}
+			if existing == "" {
+				return "", fmt.Errorf("Slack reports a canvas already exists for channel %q but it could not be found: %w", channel, err)
+			}
+			p.canvasIDs[channel] = existing
+			return existing, nil
+		}
+		return "", fmt.Errorf("while creating channel canvas: %w", err)
+	}
+
+	p.canvasIDs[channel] = id
+	p.lastPublished[channel] = body
+	p.log.WithFields(logrus.Fields{"channel": channel, "canvasID": id}).Info("Created cluster status channel canvas")
+
+	return id, nil
+}
+
+// existingCanvasID returns the channel's current canvas ID, or an empty string when it has none.
+func (p *Publisher) existingCanvasID(ctx context.Context, channelID string) (string, error) {
+	info, err := p.client.GetConversationInfoContext(ctx, &slack.GetConversationInfoInput{ChannelID: channelID})
+	if err != nil {
+		return "", fmt.Errorf("while getting info for channel %q: %w", channelID, err)
+	}
+	if info == nil || info.Properties == nil {
+		return "", nil
+	}
+
+	return info.Properties.Canvas.FileId, nil
+}
+
+// canvasTitle renders the configured canvas title template.
+func (p *Publisher) canvasTitle() (string, error) {
+	raw := strings.TrimSpace(p.cfg.Title)
+	if raw == "" {
+		raw = "{{ .ClusterName }} cluster status"
+	}
+
+	tmpl, err := template.New("canvasTitle").Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("while parsing status canvas title %q: %w", raw, err)
+	}
+
+	clusterName := p.state.Snapshot().Summary.ClusterName
+	if clusterName == "" {
+		clusterName = "Kubernetes"
+	}
+
+	var out strings.Builder
+	if err := tmpl.Execute(&out, struct{ ClusterName string }{ClusterName: clusterName}); err != nil {
+		return "", fmt.Errorf("while rendering status canvas title: %w", err)
+	}
+
+	return out.String(), nil
+}
+
+// isCanvasNotFoundError reports whether err means the canvas no longer exists.
+func isCanvasNotFoundError(err error) bool {
+	switch slackErrorCode(err) {
+	case "canvas_not_found", "file_not_found", "channel_canvas_not_found":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/status/publisher_test.go
+++ b/internal/status/publisher_test.go
@@ -1,0 +1,576 @@
+package status
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/iggy/botkube/pkg/config"
+	"github.com/iggy/botkube/pkg/loggerx"
+)
+
+// fakeCanvasClient records the canvas calls the publisher makes and replays scripted errors, so the
+// publisher's decisions can be asserted without a Slack workspace.
+type fakeCanvasClient struct {
+	mu sync.Mutex
+
+	// existingCanvasID is returned by conversations.info; empty means the channel has no canvas yet.
+	existingCanvasID string
+	// createdCanvasID is returned by a successful create.
+	createdCanvasID string
+	// existingAfterCreate becomes the existing canvas once a create has been attempted, which models
+	// another client winning the create race.
+	existingAfterCreate string
+
+	// createErr is returned by the next create call, then cleared.
+	createErr error
+	// editErr is returned by the next edit call, then cleared.
+	editErr error
+	// infoErr is returned by every conversations.info call.
+	infoErr error
+
+	channels []slack.Channel
+
+	creates []slack.DocumentContent
+	edits   []slack.EditCanvasParams
+	infos   int
+	lists   int
+}
+
+func (f *fakeCanvasClient) GetConversationInfoContext(_ context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.infos++
+	if f.infoErr != nil {
+		return nil, f.infoErr
+	}
+
+	ch := &slack.Channel{}
+	ch.ID = input.ChannelID
+	ch.Properties = &slack.Properties{Canvas: slack.Canvas{FileId: f.existingCanvasID}}
+	return ch, nil
+}
+
+func (f *fakeCanvasClient) GetConversationsContext(_ context.Context, _ *slack.GetConversationsParameters) ([]slack.Channel, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.lists++
+	return f.channels, "", nil
+}
+
+func (f *fakeCanvasClient) CreateChannelCanvasContext(_ context.Context, _ string, content slack.DocumentContent, _ ...slack.CreateChannelCanvasOption) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.creates = append(f.creates, content)
+	if f.existingAfterCreate != "" {
+		f.existingCanvasID = f.existingAfterCreate
+	}
+	if err := f.createErr; err != nil {
+		f.createErr = nil
+		return "", err
+	}
+	return f.createdCanvasID, nil
+}
+
+func (f *fakeCanvasClient) EditCanvasContext(_ context.Context, params slack.EditCanvasParams) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.edits = append(f.edits, params)
+	if err := f.editErr; err != nil {
+		f.editErr = nil
+		return err
+	}
+	return nil
+}
+
+func (f *fakeCanvasClient) snapshotCalls() (creates []slack.DocumentContent, edits []slack.EditCanvasParams) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.creates, f.edits
+}
+
+// namedChannel builds the conversations.list entry for a channel name.
+func namedChannel(id, name string) slack.Channel {
+	ch := slack.Channel{}
+	ch.ID = id
+	ch.Name = name
+	return ch
+}
+
+// newTestPublisher wires a publisher over a fake Slack client and an empty cluster.
+func newTestPublisher(t *testing.T, client CanvasClient, cfg config.StatusCanvas) (*Publisher, *ClusterState) {
+	t.Helper()
+
+	collector, err := NewCollector(loggerx.NewNoop(), fake.NewSimpleClientset(), cfg)
+	require.NoError(t, err)
+
+	state := NewClusterState("prod-eu", 10)
+	return NewPublisher(loggerx.NewNoop(), cfg, client, collector, state), state
+}
+
+func TestPublisherCreatesCanvasWithBody(t *testing.T) {
+	// given
+	client := &fakeCanvasClient{createdCanvasID: "F123", channels: []slack.Channel{namedChannel("C123", "ops")}}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	// when
+	require.NoError(t, publisher.publish(context.Background()))
+
+	// then
+	creates, edits := client.snapshotCalls()
+	require.Len(t, creates, 1)
+	assert.Equal(t, canvasMarkdownType, creates[0].Type)
+	assert.Contains(t, creates[0].Markdown, "node-1", "a new canvas should be created with content, never briefly empty")
+	assert.Empty(t, edits, "the created canvas already holds the body, so no edit is needed")
+}
+
+func TestPublisherAdoptsExistingCanvas(t *testing.T) {
+	// A canvas created by a previous Botkube run is discoverable from the channel, so there is no
+	// persisted ID and nothing to recreate.
+	client := &fakeCanvasClient{existingCanvasID: "F999", channels: []slack.Channel{namedChannel("C123", "ops")}}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	require.NoError(t, publisher.publish(context.Background()))
+
+	creates, edits := client.snapshotCalls()
+	assert.Empty(t, creates)
+	require.Len(t, edits, 1)
+	assert.Equal(t, "F999", edits[0].CanvasID)
+}
+
+func TestPublisherAdoptsCanvasAfterCreateRace(t *testing.T) {
+	// Slack rejects a second canvas for the channel. Creating and adopting are the same intent, so
+	// the publisher must fall back to the existing canvas rather than failing.
+	tests := []string{"channel_canvas_already_exists", "free_team_canvas_tab_already_exists"}
+
+	for _, slackErr := range tests {
+		t.Run(slackErr, func(t *testing.T) {
+			client := &fakeCanvasClient{
+				channels:  []slack.Channel{namedChannel("C123", "ops")},
+				createErr: slack.SlackErrorResponse{Err: slackErr},
+				// The canvas appears between the first lookup and the create.
+				existingAfterCreate: "F777",
+			}
+			publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+			state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+			require.NoError(t, publisher.publish(context.Background()))
+
+			creates, edits := client.snapshotCalls()
+			require.Len(t, creates, 1)
+			require.Len(t, edits, 1)
+			assert.Equal(t, "F777", edits[0].CanvasID)
+		})
+	}
+}
+
+func TestPublisherSkipsUnchangedBody(t *testing.T) {
+	// Rendering is deterministic, so an unchanged cluster must not spend canvases.edit rate limit.
+	client := &fakeCanvasClient{existingCanvasID: "F999", channels: []slack.Channel{namedChannel("C123", "ops")}}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	require.NoError(t, publisher.publish(context.Background()))
+	require.NoError(t, publisher.publish(context.Background()))
+
+	_, edits := client.snapshotCalls()
+	assert.Len(t, edits, 1, "a second publish of identical state should be a no-op")
+}
+
+func TestPublisherWritesChangedBody(t *testing.T) {
+	// given
+	client := &fakeCanvasClient{existingCanvasID: "F999", channels: []slack.Channel{namedChannel("C123", "ops")}}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	// when
+	require.NoError(t, publisher.publish(context.Background()))
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthFailing, Reason: "KubeletNotReady"}}})
+	require.NoError(t, publisher.publish(context.Background()))
+
+	// then
+	_, edits := client.snapshotCalls()
+	require.Len(t, edits, 2)
+	assert.Equal(t, "replace", edits[1].Changes[0].Operation)
+	// No section_id means a whole-canvas replace, which matches the full-rewrite model.
+	assert.Empty(t, edits[1].Changes[0].SectionID)
+	assert.Contains(t, edits[1].Changes[0].DocumentContent.Markdown, "KubeletNotReady")
+}
+
+func TestPublisherFatalErrorDisablesChannel(t *testing.T) {
+	// A plan restriction or missing scope never resolves on its own, so the channel is dropped and
+	// reported once instead of failing on every tick.
+	client := &fakeCanvasClient{
+		channels:  []slack.Channel{namedChannel("C123", "ops")},
+		createErr: slack.SlackErrorResponse{Err: "team_tier_cannot_create_channel_canvases"},
+	}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	err := publisher.publish(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not allow creating channel canvases")
+
+	// A later publish must not retry the doomed channel.
+	client.createdCanvasID = "F123"
+	require.NoError(t, publisher.publish(context.Background()))
+
+	creates, _ := client.snapshotCalls()
+	assert.Len(t, creates, 1, "a permanently failing channel should be attempted only once")
+}
+
+func TestPublisherRetriesTransientError(t *testing.T) {
+	// A rate limit or a network blip is not a reason to give up on the channel.
+	client := &fakeCanvasClient{
+		existingCanvasID: "F999",
+		channels:         []slack.Channel{namedChannel("C123", "ops")},
+		editErr:          slack.SlackErrorResponse{Err: "ratelimited"},
+	}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	require.Error(t, publisher.publish(context.Background()))
+	require.NoError(t, publisher.publish(context.Background()), "the next attempt should succeed")
+
+	_, edits := client.snapshotCalls()
+	assert.Len(t, edits, 2)
+}
+
+func TestPublisherRediscoversDeletedCanvas(t *testing.T) {
+	// A canvas deleted in Slack leaves a stale cached ID. Editing it would fail forever, so the ID is
+	// dropped and the next attempt recreates the canvas.
+	client := &fakeCanvasClient{
+		existingCanvasID: "F999",
+		createdCanvasID:  "F111",
+		channels:         []slack.Channel{namedChannel("C123", "ops")},
+		editErr:          slack.SlackErrorResponse{Err: "canvas_not_found"},
+	}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	require.Error(t, publisher.publish(context.Background()))
+	client.existingCanvasID = ""
+
+	require.NoError(t, publisher.publish(context.Background()))
+
+	creates, _ := client.snapshotCalls()
+	require.Len(t, creates, 1, "the canvas should be recreated once the cached ID is known to be gone")
+}
+
+func TestPublisherPublishesToEveryChannel(t *testing.T) {
+	// given
+	client := &fakeCanvasClient{
+		existingCanvasID: "F999",
+		channels:         []slack.Channel{namedChannel("C123", "ops"), namedChannel("C456", "alerts")},
+	}
+	publisher, state := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"ops", "#alerts"}})
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	// when
+	require.NoError(t, publisher.publish(context.Background()))
+
+	// then
+	_, edits := client.snapshotCalls()
+	assert.Len(t, edits, 2, "a leading # in the configured channel should not prevent resolution")
+}
+
+func TestPublisherReportsUnknownChannel(t *testing.T) {
+	// given
+	client := &fakeCanvasClient{channels: []slack.Channel{namedChannel("C123", "ops")}}
+	publisher, _ := newTestPublisher(t, client, config.StatusCanvas{Channels: []string{"missing"}})
+
+	// when
+	err := publisher.publish(context.Background())
+
+	// then
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "make sure Botkube is invited to it")
+}
+
+func TestCanvasTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		title       string
+		clusterName string
+		expected    string
+	}{
+		{
+			name:        "cluster name is interpolated",
+			title:       "{{ .ClusterName }} cluster status",
+			clusterName: "prod-eu",
+			expected:    "prod-eu cluster status",
+		},
+		{
+			name:        "static title is kept",
+			title:       "Cluster status",
+			clusterName: "prod-eu",
+			expected:    "Cluster status",
+		},
+		{
+			name:        "empty title falls back to the default",
+			clusterName: "prod-eu",
+			expected:    "prod-eu cluster status",
+		},
+		{
+			// A canvas titled " cluster status" would read as a bug, so an unset cluster name gets a
+			// placeholder.
+			name:     "missing cluster name falls back",
+			title:    "{{ .ClusterName }} cluster status",
+			expected: "Kubernetes cluster status",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			collector, err := NewCollector(loggerx.NewNoop(), fake.NewSimpleClientset(), config.StatusCanvas{})
+			require.NoError(t, err)
+
+			publisher := NewPublisher(
+				loggerx.NewNoop(),
+				config.StatusCanvas{Title: tc.title},
+				&fakeCanvasClient{},
+				collector,
+				NewClusterState(tc.clusterName, 10),
+			)
+
+			out, err := publisher.canvasTitle()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, out)
+		})
+	}
+}
+
+func TestCanvasTitleRejectsBrokenTemplate(t *testing.T) {
+	collector, err := NewCollector(loggerx.NewNoop(), fake.NewSimpleClientset(), config.StatusCanvas{})
+	require.NoError(t, err)
+
+	publisher := NewPublisher(
+		loggerx.NewNoop(),
+		config.StatusCanvas{Title: "{{ .ClusterName "},
+		&fakeCanvasClient{},
+		collector,
+		NewClusterState("prod-eu", 10),
+	)
+
+	_, err = publisher.canvasTitle()
+	require.Error(t, err)
+}
+
+func TestPublisherStartPublishesImmediately(t *testing.T) {
+	// The canvas must be correct as soon as Botkube is up, not blank until the first tick.
+	k8sCli := fake.NewSimpleClientset(namespace("app"), readyNode("node-1"))
+	cfg := config.StatusCanvas{
+		Channels:         []string{"ops"},
+		UpdateInterval:   minUpdateInterval,
+		SnapshotInterval: time.Minute,
+	}
+	collector, err := NewCollector(loggerx.NewNoop(), k8sCli, cfg)
+	require.NoError(t, err)
+
+	client := &fakeCanvasClient{createdCanvasID: "F123", channels: []slack.Channel{namedChannel("C123", "ops")}}
+	publisher := NewPublisher(loggerx.NewNoop(), cfg, client, collector, NewClusterState("prod-eu", 10))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- publisher.Start(ctx) }()
+
+	assert.Eventually(t, func() bool {
+		creates, _ := client.snapshotCalls()
+		return len(creates) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done, "a cancelled context should shut down cleanly")
+}
+
+func TestPublisherStartCoalescesEvents(t *testing.T) {
+	// The debounce window is the point of the update ticker: a burst of events must produce one canvas
+	// write, not one per event.
+	k8sCli := fake.NewSimpleClientset(namespace("app"), readyNode("node-1"))
+	cfg := config.StatusCanvas{
+		Channels:         []string{"ops"},
+		UpdateInterval:   minUpdateInterval,
+		SnapshotInterval: time.Hour,
+	}
+	collector, err := NewCollector(loggerx.NewNoop(), k8sCli, cfg)
+	require.NoError(t, err)
+
+	client := &fakeCanvasClient{existingCanvasID: "F999", channels: []slack.Channel{namedChannel("C123", "ops")}}
+	state := NewClusterState("prod-eu", 10)
+	publisher := NewPublisher(loggerx.NewNoop(), cfg, client, collector, state)
+	observer := NewObserver(loggerx.NewNoop(), state, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- publisher.Start(ctx) }()
+
+	// Wait for the initial publish so later writes are attributable to the burst.
+	require.Eventually(t, func() bool {
+		_, edits := client.snapshotCalls()
+		return len(edits) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// A hundred warnings for distinct pods, all inside one debounce window.
+	for i := range 100 {
+		observer.ObserveEvent("botkube/kubernetes", map[string]any{
+			"Kind":      "Pod",
+			"Name":      "pod-" + string(rune('a'+i%26)),
+			"Namespace": "app",
+			"Level":     string(config.Error),
+			"Reason":    "BackOff",
+			"Messages":  []string{"burst"},
+			"Count":     i,
+		})
+	}
+
+	require.Eventually(t, func() bool {
+		_, edits := client.snapshotCalls()
+		return len(edits) == 2
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Give the ticker room to fire again; a correct debounce writes nothing more once state settles.
+	time.Sleep(3 * minUpdateInterval)
+
+	_, edits := client.snapshotCalls()
+	assert.Len(t, edits, 2, "a burst of 100 events should collapse into a single canvas write")
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestPublisherStartFloorsUpdateInterval(t *testing.T) {
+	// canvases.edit is rate limited, so a sub-second interval configured by mistake must not be
+	// honoured as written.
+	cfg := config.StatusCanvas{Channels: []string{"ops"}, UpdateInterval: time.Millisecond}
+	collector, err := NewCollector(loggerx.NewNoop(), fake.NewSimpleClientset(), cfg)
+	require.NoError(t, err)
+
+	client := &fakeCanvasClient{existingCanvasID: "F999", channels: []slack.Channel{namedChannel("C123", "ops")}}
+	publisher := NewPublisher(loggerx.NewNoop(), cfg, client, collector, NewClusterState("prod-eu", 10))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	require.NoError(t, publisher.Start(ctx))
+
+	// With the interval floored to seconds, a one-second run cannot produce a flood of writes.
+	_, edits := client.snapshotCalls()
+	assert.LessOrEqual(t, len(edits), 2)
+}
+
+func TestExistingCanvasIDHandlesChannelWithoutProperties(t *testing.T) {
+	// conversations.info omits properties for a channel that never had a canvas; that is an absent
+	// canvas, not an error.
+	client := &fakeCanvasClient{}
+	publisher, _ := newTestPublisher(t, client, config.StatusCanvas{})
+
+	id, err := publisher.existingCanvasID(context.Background(), "C123")
+
+	require.NoError(t, err)
+	assert.Empty(t, id)
+}
+
+func TestFatalCanvasError(t *testing.T) {
+	tests := []struct {
+		slackErr string
+		fatal    bool
+	}{
+		{slackErr: "team_tier_cannot_create_channel_canvases", fatal: true},
+		{slackErr: "canvas_disabled_user_team", fatal: true},
+		{slackErr: "missing_scope", fatal: true},
+		{slackErr: "not_allowed_token_type", fatal: true},
+		// Transient failures must stay retryable.
+		{slackErr: "ratelimited", fatal: false},
+		{slackErr: "channel_not_found", fatal: false},
+		{slackErr: "channel_canvas_already_exists", fatal: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.slackErr, func(t *testing.T) {
+			err := fatalCanvasError(slack.SlackErrorResponse{Err: tc.slackErr})
+			assert.Equal(t, tc.fatal, err != nil)
+		})
+	}
+
+	assert.Nil(t, fatalCanvasError(nil))
+}
+
+func TestLooksLikeChannelID(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected bool
+	}{
+		{in: "C0123456789", expected: true},
+		{in: "G0123456789", expected: true},
+		{in: "D0123456789", expected: true},
+		// Channel names are lowercase, so any lowercase rules out an ID.
+		{in: "channel-name", expected: false},
+		{in: "C0123456789a", expected: false},
+		{in: "ops", expected: false},
+		{in: "", expected: false},
+		{in: "X0123456789", expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.expected, looksLikeChannelID(tc.in))
+		})
+	}
+}
+
+func TestChannelResolverCachesLookups(t *testing.T) {
+	// Channel IDs are stable, so paging conversations.list on every debounce tick would be waste.
+	// "alerts" is listed first so resolving "ops" walks past it, which is what gets it cached.
+	client := &fakeCanvasClient{channels: []slack.Channel{namedChannel("C456", "alerts"), namedChannel("C123", "ops")}}
+	resolver := newChannelResolver(client)
+
+	for range 3 {
+		id, err := resolver.Resolve(context.Background(), "ops")
+		require.NoError(t, err)
+		assert.Equal(t, "C123", id)
+	}
+
+	// Channels seen while paging are cached too, so a second configured channel is free.
+	id, err := resolver.Resolve(context.Background(), "alerts")
+	require.NoError(t, err)
+	assert.Equal(t, "C456", id)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	assert.Equal(t, 1, client.lists)
+}
+
+func TestChannelResolverAcceptsChannelID(t *testing.T) {
+	// given
+	client := &fakeCanvasClient{}
+	resolver := newChannelResolver(client)
+
+	// when
+	id, err := resolver.Resolve(context.Background(), "C0123456789")
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, "C0123456789", id)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	assert.Zero(t, client.lists, "an ID needs no conversations.list paging")
+}
+
+func TestChannelResolverRejectsEmptyChannel(t *testing.T) {
+	_, err := newChannelResolver(&fakeCanvasClient{}).Resolve(context.Background(), "")
+	require.Error(t, err)
+}

--- a/internal/status/render.go
+++ b/internal/status/render.go
@@ -1,0 +1,251 @@
+package status
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/iggy/botkube/pkg/config"
+)
+
+const (
+	defaultNodesLimit     = 25
+	defaultWorkloadsLimit = 25
+	defaultCatalogLimit   = 50
+	defaultWarningsLimit  = 15
+
+	// maxMessageLen bounds how much of a warning message is shown, so one verbose event cannot push
+	// the rest of the table off screen.
+	maxMessageLen = 160
+)
+
+var healthIcon = map[Health]string{
+	HealthOK:       ":large_green_circle:",
+	HealthDegraded: ":large_yellow_circle:",
+	HealthFailing:  ":red_circle:",
+	HealthUnknown:  ":white_circle:",
+}
+
+var healthLabel = map[Health]string{
+	HealthOK:       "Healthy",
+	HealthDegraded: "Degraded",
+	HealthFailing:  "Failing",
+	HealthUnknown:  "Unknown",
+}
+
+// Renderer turns a Snapshot into the canvas markdown body.
+//
+// Render is a pure function of its input: determinism is load-bearing, because the publisher skips
+// writing the canvas when the rendered body is unchanged from the last write.
+type Renderer struct {
+	cfg config.StatusCanvas
+}
+
+// NewRenderer returns a Renderer for the given configuration.
+func NewRenderer(cfg config.StatusCanvas) *Renderer {
+	return &Renderer{cfg: cfg}
+}
+
+// Render returns the full canvas markdown body for the given snapshot.
+func (r *Renderer) Render(snap Snapshot) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "# %s %s\n\n", healthIcon[snap.Summary.Health], clusterTitle(snap.Summary.ClusterName))
+	fmt.Fprintf(&b, "**Status:** %s\n", healthLabel[snap.Summary.Health])
+	if snap.Summary.KubernetesVer != "" {
+		fmt.Fprintf(&b, "**Kubernetes:** `%s`\n", snap.Summary.KubernetesVer)
+	}
+	fmt.Fprintf(&b, "**Nodes:** %d/%d ready\n", snap.Summary.NodesReady, snap.Summary.NodesTotal)
+	fmt.Fprintf(&b, "**Pods:** %d total, %d unhealthy\n", snap.Summary.PodsTotal, snap.Summary.PodsUnhealthy)
+	fmt.Fprintf(&b, "**Workloads:** %d in %d namespaces\n", snap.Summary.WorkloadsTotal, snap.Summary.NamespacesInScope)
+	fmt.Fprintf(&b, "**Updated:** %s\n", formatTimestamp(snap.Summary.SnapshotAt))
+
+	if !r.cfg.Sections.Nodes.Disabled {
+		r.renderNodes(&b, snap.Nodes)
+	}
+	if !r.cfg.Sections.Workloads.Disabled {
+		r.renderWorkloads(&b, snap.Workloads)
+	}
+	if !r.cfg.Sections.Catalog.Disabled {
+		r.renderCatalog(&b, snap.Catalog)
+	}
+	if !r.cfg.Sections.Warnings.Disabled {
+		r.renderWarnings(&b, snap.Warnings)
+	}
+
+	b.WriteString("\n---\n\n")
+	b.WriteString("_Maintained by Botkube. Manual edits are overwritten on the next update._\n")
+
+	return b.String()
+}
+
+func clusterTitle(name string) string {
+	if name == "" {
+		return "Kubernetes cluster"
+	}
+	return name
+}
+
+func (r *Renderer) renderNodes(b *strings.Builder, nodes []Node) {
+	b.WriteString("\n## Nodes\n\n")
+	if len(nodes) == 0 {
+		b.WriteString("_No nodes found._\n")
+		return
+	}
+
+	limit := limitFor(r.cfg.Sections.Nodes.Limit, defaultNodesLimit)
+	shown, omitted := capEntries(nodes, limit)
+
+	b.WriteString("| | Node | Ready | Schedulable | Kubelet | Reason |\n")
+	b.WriteString("|---|---|---|---|---|---|\n")
+	for _, n := range shown {
+		schedulable := "yes"
+		if !n.Schedulable {
+			schedulable = "no"
+		}
+		fmt.Fprintf(b, "| %s | %s | %s | %s | `%s` | %s |\n",
+			healthIcon[n.Health], escapeCell(n.Name), escapeCell(n.Ready), schedulable, escapeCell(n.KubeletVer), escapeCell(n.Reason))
+	}
+	writeOmitted(b, omitted, "nodes")
+}
+
+func (r *Renderer) renderWorkloads(b *strings.Builder, workloads []Workload) {
+	b.WriteString("\n## Unhealthy workloads\n\n")
+	if len(workloads) == 0 {
+		b.WriteString("_All workloads are healthy._\n")
+		return
+	}
+
+	limit := limitFor(r.cfg.Sections.Workloads.Limit, defaultWorkloadsLimit)
+	shown, omitted := capEntries(workloads, limit)
+
+	b.WriteString("| | Kind | Namespace | Name | Ready | Restarts | Reason |\n")
+	b.WriteString("|---|---|---|---|---|---|---|\n")
+	for _, w := range shown {
+		restarts := ""
+		if w.Restarts > 0 {
+			restarts = fmt.Sprintf("%d", w.Restarts)
+		}
+		fmt.Fprintf(b, "| %s | %s | `%s` | %s | %d/%d | %s | %s |\n",
+			healthIcon[w.Health], escapeCell(w.Kind), escapeCell(w.Namespace), escapeCell(w.Name), w.Ready, w.Desired, restarts, escapeCell(w.Reason))
+	}
+	writeOmitted(b, omitted, "workloads")
+}
+
+func (r *Renderer) renderCatalog(b *strings.Builder, catalog []CatalogEntry) {
+	b.WriteString("\n## Service catalog\n\n")
+	if len(catalog) == 0 {
+		b.WriteString("_No workloads opted in. Add the configured label to include a workload._\n")
+		return
+	}
+
+	limit := limitFor(r.cfg.Sections.Catalog.Limit, defaultCatalogLimit)
+	shown, omitted := capEntries(catalog, limit)
+
+	b.WriteString("| | Workload | Namespace | Container | Version | Ready | Rollout |\n")
+	b.WriteString("|---|---|---|---|---|---|---|\n")
+	for _, entry := range shown {
+		rollout := "settled"
+		if entry.RollingOut {
+			rollout = ":arrows_counterclockwise: in progress"
+		}
+
+		if len(entry.Images) == 0 {
+			fmt.Fprintf(b, "| %s | %s | `%s` | | | %d/%d | %s |\n",
+				healthIcon[entry.Health], escapeCell(entry.Name), escapeCell(entry.Namespace), entry.Ready, entry.Desired, rollout)
+			continue
+		}
+
+		for i, img := range entry.Images {
+			if i == 0 {
+				fmt.Fprintf(b, "| %s | %s | `%s` | `%s` | `%s` | %d/%d | %s |\n",
+					healthIcon[entry.Health], escapeCell(entry.Name), escapeCell(entry.Namespace), escapeCell(img.Container), escapeCell(img.Version), entry.Ready, entry.Desired, rollout)
+				continue
+			}
+			fmt.Fprintf(b, "| | | | `%s` | `%s` | | |\n", escapeCell(img.Container), escapeCell(img.Version))
+		}
+	}
+	writeOmitted(b, omitted, "catalog entries")
+}
+
+func (r *Renderer) renderWarnings(b *strings.Builder, warnings []Warning) {
+	b.WriteString("\n## Recent warnings\n\n")
+	if len(warnings) == 0 {
+		b.WriteString("_No recent warnings._\n")
+		return
+	}
+
+	limit := limitFor(r.cfg.Sections.Warnings.Limit, defaultWarningsLimit)
+	shown, omitted := capEntries(warnings, limit)
+
+	b.WriteString("| Age | Object | Reason | Count | Message |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	for _, w := range shown {
+		count := ""
+		if w.Count > 0 {
+			count = fmt.Sprintf("x%d", w.Count)
+		}
+		fmt.Fprintf(b, "| %s | %s/%s/%s | %s | %s | %s |\n",
+			formatTimestamp(w.Timestamp), escapeCell(w.Namespace), escapeCell(w.Kind), escapeCell(w.Name),
+			escapeCell(w.Reason), count, escapeCell(truncateText(w.Message, maxMessageLen)))
+	}
+	writeOmitted(b, omitted, "warnings")
+}
+
+func limitFor(configured, def int) int {
+	if configured > 0 {
+		return configured
+	}
+	if configured < 0 {
+		return 0
+	}
+	return def
+}
+
+// capEntries returns up to limit entries and the number omitted. A limit of 0 means unlimited.
+func capEntries[T any](in []T, limit int) ([]T, int) {
+	if limit <= 0 || len(in) <= limit {
+		return in, 0
+	}
+	return in[:limit], len(in) - limit
+}
+
+// writeOmitted reports how many entries were capped, so a partial section never looks complete.
+func writeOmitted(b *strings.Builder, omitted int, noun string) {
+	if omitted <= 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n_...and %d more %s not shown._\n", omitted, noun)
+}
+
+// formatTimestamp renders an absolute UTC timestamp.
+//
+// A relative age such as "5m ago" would change on every render even when the cluster did not,
+// defeating the publisher's no-op detection and rewriting the canvas forever.
+func formatTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	return t.UTC().Format("Mon, 02 Jan 2006 15:04:05 MST")
+}
+
+// escapeCell escapes characters that would corrupt a markdown table cell: a pipe would open a new
+// column, and a newline would end the row.
+func escapeCell(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}
+
+// truncateText cuts on rune boundaries so a byte-based cut cannot split a multi-byte rune.
+func truncateText(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "…"
+}

--- a/internal/status/render_test.go
+++ b/internal/status/render_test.go
@@ -1,0 +1,188 @@
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/golden"
+
+	"github.com/iggy/botkube/pkg/config"
+)
+
+// This test is based on golden files. To update them, run:
+// go test ./internal/status/... -test.update-golden
+
+// fixedTime keeps the rendered output deterministic; a wall clock would make the golden files churn.
+var fixedTime = time.Date(2026, time.August, 1, 12, 30, 0, 0, time.UTC)
+
+func fullSnapshot() Snapshot {
+	return Snapshot{
+		Summary: Summary{
+			ClusterName:       "prod-eu",
+			KubernetesVer:     "v1.34.2",
+			NodesTotal:        3,
+			NodesReady:        2,
+			NamespacesInScope: 4,
+			PodsTotal:         42,
+			PodsUnhealthy:     2,
+			WorkloadsTotal:    17,
+			Health:            HealthFailing,
+			SnapshotAt:        fixedTime,
+		},
+		Nodes: []Node{
+			{Name: "node-1", Health: HealthOK, Ready: "True", Schedulable: true, KubeletVer: "v1.34.2"},
+			{Name: "node-2", Health: HealthFailing, Ready: "False", Schedulable: true, KubeletVer: "v1.34.2", Reason: "KubeletNotReady"},
+			{Name: "node-3", Health: HealthDegraded, Ready: "True", Schedulable: false, KubeletVer: "v1.34.1", Reason: "unschedulable"},
+		},
+		Workloads: []Workload{
+			{Kind: "Pod", Namespace: "shop", Name: "api-7c9d-x2k", Health: HealthFailing, Ready: 0, Desired: 1, Reason: "CrashLoopBackOff", Restarts: 12},
+			{Kind: "Deployment", Namespace: "shop", Name: "web", Health: HealthDegraded, Ready: 2, Desired: 3, Reason: "2/3 ready"},
+		},
+		Catalog: []CatalogEntry{
+			{
+				Kind: "Deployment", Namespace: "shop", Name: "api",
+				Images: []ContainerImage{
+					{Container: "api", Image: "ghcr.io/acme/api:1.4.2", Version: "1.4.2"},
+					{Container: "sidecar", Image: "ghcr.io/acme/proxy:2.0.0", Version: "2.0.0"},
+				},
+				Ready: 3, Desired: 3, Health: HealthOK,
+			},
+			{
+				Kind: "Deployment", Namespace: "shop", Name: "web",
+				Images: []ContainerImage{{Container: "web", Image: "ghcr.io/acme/web:2.1.0", Version: "2.1.0"}},
+				Ready:  2, Desired: 3,
+				RollingOut: true, Health: HealthDegraded,
+			},
+		},
+		Warnings: []Warning{
+			{Namespace: "shop", Kind: "Pod", Name: "api-7c9d-x2k", Reason: "BackOff", Message: "Back-off restarting failed container", Count: 12, Timestamp: fixedTime},
+			{Namespace: "shop", Kind: "Pod", Name: "web-1", Reason: "Unhealthy", Message: "Readiness probe failed", Count: 1, Timestamp: fixedTime.Add(-2 * time.Minute)},
+		},
+	}
+}
+
+func TestRenderFullSnapshot(t *testing.T) {
+	// given
+	r := NewRenderer(config.StatusCanvas{})
+
+	// when
+	out := r.Render(fullSnapshot())
+
+	// then
+	golden.Assert(t, out, filepath.Join(t.Name(), "canvas.golden.md"))
+}
+
+func TestRenderEmptyCluster(t *testing.T) {
+	// given
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Catalog.LabelSelector = "botkube.io/canvas=true"
+	r := NewRenderer(cfg)
+
+	// when
+	out := r.Render(Snapshot{Summary: Summary{ClusterName: "empty", Health: HealthUnknown}})
+
+	// then
+	golden.Assert(t, out, filepath.Join(t.Name(), "canvas.golden.md"))
+}
+
+func TestRenderIsDeterministic(t *testing.T) {
+	// The publisher skips a canvas write when the rendered body is unchanged, which only holds if
+	// rendering the same snapshot twice yields identical bytes.
+	r := NewRenderer(config.StatusCanvas{})
+
+	first := r.Render(fullSnapshot())
+	second := r.Render(fullSnapshot())
+
+	assert.Equal(t, first, second)
+}
+
+func TestRenderDisabledSections(t *testing.T) {
+	// given
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Nodes.Disabled = true
+	cfg.Sections.Catalog.Disabled = true
+	cfg.Sections.Warnings.Disabled = true
+	r := NewRenderer(cfg)
+
+	// when
+	out := r.Render(fullSnapshot())
+
+	// then
+	assert.NotContains(t, out, "## Nodes")
+	assert.NotContains(t, out, "## Service catalog")
+	assert.NotContains(t, out, "## Recent warnings")
+	assert.Contains(t, out, "## Unhealthy workloads")
+}
+
+func TestRenderReportsOmittedEntries(t *testing.T) {
+	// A cap that silently dropped entries would make a partial section look complete.
+	cfg := config.StatusCanvas{}
+	cfg.Sections.Nodes.Limit = 2
+	r := NewRenderer(cfg)
+
+	out := r.Render(fullSnapshot())
+
+	assert.Contains(t, out, "_...and 1 more nodes not shown._")
+	assert.Contains(t, out, "node-2")
+	assert.NotContains(t, out, "node-3")
+}
+
+func TestRenderEscapesTableCells(t *testing.T) {
+	// A pipe would open a new column and a newline would end the row, corrupting every later row.
+	r := NewRenderer(config.StatusCanvas{})
+
+	out := r.Render(Snapshot{
+		Warnings: []Warning{{
+			Namespace: "default",
+			Kind:      "Pod",
+			Name:      "weird",
+			Reason:    "Failed",
+			Message:   "command failed: sh -c 'a | b'\nsecond line",
+			Count:     1,
+			Timestamp: fixedTime,
+		}},
+	})
+
+	require.Contains(t, out, "\\|")
+	// The row must remain a single line, otherwise the table breaks.
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(line, "command failed") {
+			assert.Contains(t, line, "second line", "message should be flattened onto one row")
+		}
+	}
+}
+
+func TestTruncateText(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		max      int
+		expected string
+	}{
+		{name: "under limit is untouched", in: "short", max: 10, expected: "short"},
+		{name: "over limit is truncated", in: "abcdefghij", max: 5, expected: "abcde…"},
+		{name: "zero limit disables truncation", in: "abcdefghij", max: 0, expected: "abcdefghij"},
+		// A byte-based cut would split the multi-byte rune and emit invalid UTF-8.
+		{name: "multi-byte runes are not split", in: "日本語テスト", max: 3, expected: "日本語…"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, truncateText(tc.in, tc.max))
+		})
+	}
+}
+
+func TestFormatTimestampIsStable(t *testing.T) {
+	// A relative age such as "5m ago" would change on every render even when the cluster did not,
+	// defeating the publisher's no-op detection and rewriting the canvas forever.
+	inUTC := formatTimestamp(fixedTime)
+	inOtherZone := formatTimestamp(fixedTime.In(time.FixedZone("UTC+9", 9*60*60)))
+
+	assert.Equal(t, inUTC, inOtherZone)
+	assert.Equal(t, "unknown", formatTimestamp(time.Time{}))
+}

--- a/internal/status/state.go
+++ b/internal/status/state.go
@@ -1,0 +1,338 @@
+package status
+
+import (
+	"slices"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Section identifies one part of the rendered canvas.
+type Section string
+
+const (
+	// SectionSummary is the cluster-wide summary section.
+	SectionSummary Section = "summary"
+	// SectionNodes is the node health section.
+	SectionNodes Section = "nodes"
+	// SectionWorkloads is the unhealthy workloads section.
+	SectionWorkloads Section = "workloads"
+	// SectionCatalog is the service catalog section.
+	SectionCatalog Section = "catalog"
+	// SectionWarnings is the recent warning events section.
+	SectionWarnings Section = "warnings"
+)
+
+// Health describes the health of a single entry or of the cluster as a whole.
+type Health string
+
+const (
+	// HealthOK means the entry is in its desired state.
+	HealthOK Health = "ok"
+	// HealthDegraded means the entry is impaired but still serving.
+	HealthDegraded Health = "degraded"
+	// HealthFailing means the entry is not serving at all.
+	HealthFailing Health = "failing"
+	// HealthUnknown means health could not be determined.
+	HealthUnknown Health = "unknown"
+)
+
+// severity ranks health from best to worst, so the worse of two values can be picked.
+var severity = map[Health]int{
+	HealthOK:       0,
+	HealthUnknown:  1,
+	HealthDegraded: 2,
+	HealthFailing:  3,
+}
+
+// WorseOf returns whichever of a and b is worse.
+//
+// Unknown ranks worse than OK: a health that could not be determined should not read as healthy.
+func WorseOf(a, b Health) Health {
+	if severity[b] > severity[a] {
+		return b
+	}
+	return a
+}
+
+// Summary holds cluster-wide counters and the overall health verdict.
+type Summary struct {
+	ClusterName       string
+	KubernetesVer     string
+	NodesTotal        int
+	NodesReady        int
+	NamespacesInScope int
+	PodsTotal         int
+	PodsUnhealthy     int
+	WorkloadsTotal    int
+	Health            Health
+	SnapshotAt        time.Time
+}
+
+// Node describes one cluster node.
+type Node struct {
+	Name        string
+	Health      Health
+	Ready       string
+	Schedulable bool
+	KubeletVer  string
+	Reason      string
+}
+
+// Workload describes one workload or pod that is not in its desired state.
+type Workload struct {
+	Kind      string
+	Namespace string
+	Name      string
+	Health    Health
+	Ready     int32
+	Desired   int32
+	Reason    string
+	Restarts  int32
+}
+
+// ContainerImage describes one container's declared image and version.
+type ContainerImage struct {
+	Container string
+	Image     string
+	Version   string
+}
+
+// CatalogEntry describes one opt-in workload in the service catalog.
+type CatalogEntry struct {
+	Kind       string
+	Namespace  string
+	Name       string
+	Images     []ContainerImage
+	Ready      int32
+	Desired    int32
+	RollingOut bool
+	Health     Health
+}
+
+// Warning describes one recent warning event.
+type Warning struct {
+	Namespace string
+	Kind      string
+	Name      string
+	Reason    string
+	Message   string
+	Count     int32
+	Timestamp time.Time
+}
+
+// key identifies the object/reason a warning is about, used to update an existing entry instead of
+// appending a duplicate for every occurrence.
+func (w Warning) key() string {
+	return w.Namespace + "/" + w.Kind + "/" + w.Name + "/" + w.Reason
+}
+
+// SnapshotData is the output of a single collection pass.
+type SnapshotData struct {
+	Summary   Summary
+	Nodes     []Node
+	Workloads []Workload
+	Catalog   []CatalogEntry
+	Warnings  []Warning
+}
+
+// Snapshot is a point-in-time, read-only view of the cluster state.
+type Snapshot struct {
+	Summary   Summary
+	Nodes     []Node
+	Workloads []Workload
+	Catalog   []CatalogEntry
+	Warnings  []Warning
+}
+
+// defaultMaxWarnings bounds the warnings ring buffer when none is configured.
+const defaultMaxWarnings = 50
+
+// ClusterState holds the current view of the cluster, built from a mix of periodic snapshots and
+// event deltas. It is safe for concurrent use: the event observer writes while the publisher reads.
+type ClusterState struct {
+	mu sync.Mutex
+
+	clusterName string
+	revision    int64
+	maxWarnings int
+
+	summary   Summary
+	nodes     []Node
+	workloads []Workload
+	catalog   []CatalogEntry
+	warnings  []Warning
+
+	stale map[Section]struct{}
+}
+
+// NewClusterState returns an empty ClusterState for the given cluster name.
+func NewClusterState(clusterName string, maxWarnings int) *ClusterState {
+	if maxWarnings <= 0 {
+		maxWarnings = defaultMaxWarnings
+	}
+	return &ClusterState{
+		clusterName: clusterName,
+		maxWarnings: maxWarnings,
+		summary:     Summary{ClusterName: clusterName, Health: HealthUnknown},
+		stale:       map[Section]struct{}{},
+	}
+}
+
+// Revision returns a counter that increases every time the state changes in a way that would change
+// the rendered canvas. The publisher uses this to skip redundant renders.
+func (s *ClusterState) Revision() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.revision
+}
+
+// Snapshot returns a deep copy of the current state, safe to render outside the lock.
+func (s *ClusterState) Snapshot() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return Snapshot{
+		Summary:   s.summary,
+		Nodes:     append([]Node(nil), s.nodes...),
+		Workloads: append([]Workload(nil), s.workloads...),
+		Catalog:   append([]CatalogEntry(nil), s.catalog...),
+		Warnings:  append([]Warning(nil), s.warnings...),
+	}
+}
+
+// ApplySnapshot replaces the collected sections with a fresh full snapshot, deriving the overall
+// health from it. Clears any pending stale flags, since a full snapshot already refreshed everything.
+func (s *ClusterState) ApplySnapshot(data SnapshotData) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.nodes = sortedNodes(data.Nodes)
+	s.workloads = sortedWorkloads(data.Workloads)
+	s.catalog = sortedCatalog(data.Catalog)
+
+	summary := data.Summary
+	summary.ClusterName = s.clusterName
+	summary.Health = deriveHealth(s.nodes, s.workloads)
+	s.summary = summary
+
+	s.stale = map[Section]struct{}{}
+	s.revision++
+}
+
+// AddWarning applies a single warning event, updating an existing entry for the same object/reason
+// in place rather than appending a duplicate. The running count never walks backwards, since events
+// can be delivered out of order.
+func (s *ClusterState) AddWarning(w Warning) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := w.key()
+	for i, existing := range s.warnings {
+		if existing.key() != key {
+			continue
+		}
+		if w.Count > existing.Count {
+			s.warnings[i].Count = w.Count
+		}
+		if w.Timestamp.After(existing.Timestamp) {
+			s.warnings[i].Timestamp = w.Timestamp
+			s.warnings[i].Message = w.Message
+		}
+		s.revision++
+		return
+	}
+
+	s.warnings = append(s.warnings, w)
+	s.warnings = capWarnings(s.warnings, s.maxWarnings)
+	s.revision++
+}
+
+// MarkStale flags the given sections as needing a re-collect.
+//
+// This deliberately does not bump the revision: marking stale means "re-collect this", not "the
+// canvas changed". Bumping here would publish an unchanged canvas on every event that carries no
+// renderable data.
+func (s *ClusterState) MarkStale(sections ...Section) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, section := range sections {
+		s.stale[section] = struct{}{}
+	}
+}
+
+// TakeStale returns the sections flagged stale since the last call and clears the flags.
+func (s *ClusterState) TakeStale() []Section {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.stale) == 0 {
+		return nil
+	}
+
+	out := make([]Section, 0, len(s.stale))
+	for section := range s.stale {
+		out = append(out, section)
+	}
+	s.stale = map[Section]struct{}{}
+
+	slices.Sort(out)
+	return out
+}
+
+// deriveHealth reduces the collected entries to a single cluster verdict.
+func deriveHealth(nodes []Node, workloads []Workload) Health {
+	if len(nodes) == 0 {
+		return HealthUnknown
+	}
+
+	health := HealthOK
+	for _, n := range nodes {
+		health = WorseOf(health, n.Health)
+	}
+	for _, w := range workloads {
+		health = WorseOf(health, w.Health)
+	}
+	return health
+}
+
+func sortedNodes(in []Node) []Node {
+	out := append([]Node(nil), in...)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func sortedWorkloads(in []Workload) []Workload {
+	out := append([]Workload(nil), in...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func sortedCatalog(in []CatalogEntry) []CatalogEntry {
+	out := append([]CatalogEntry(nil), in...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// capWarnings trims to maxLen, dropping the oldest entries and keeping the newest first.
+func capWarnings(in []Warning, maxLen int) []Warning {
+	sort.Slice(in, func(i, j int) bool { return in[i].Timestamp.After(in[j].Timestamp) })
+	if len(in) > maxLen {
+		in = in[:maxLen]
+	}
+	return in
+}

--- a/internal/status/state_test.go
+++ b/internal/status/state_test.go
@@ -1,0 +1,227 @@
+package status
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplySnapshotDerivesOverallHealth(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodes     []Node
+		workloads []Workload
+		expected  Health
+	}{
+		{
+			name:     "no nodes is unknown",
+			expected: HealthUnknown,
+		},
+		{
+			name:     "all healthy",
+			nodes:    []Node{{Name: "a", Health: HealthOK}},
+			expected: HealthOK,
+		},
+		{
+			name:      "a degraded workload degrades the cluster",
+			nodes:     []Node{{Name: "a", Health: HealthOK}},
+			workloads: []Workload{{Name: "w", Health: HealthDegraded}},
+			expected:  HealthDegraded,
+		},
+		{
+			// The verdict takes the worst entry, so one failure is not masked by many healthy ones.
+			name:      "a failing workload outweighs healthy nodes",
+			nodes:     []Node{{Name: "a", Health: HealthOK}, {Name: "b", Health: HealthOK}},
+			workloads: []Workload{{Name: "w", Health: HealthFailing}, {Name: "x", Health: HealthOK}},
+			expected:  HealthFailing,
+		},
+		{
+			name:     "a failing node outweighs a degraded one",
+			nodes:    []Node{{Name: "a", Health: HealthDegraded}, {Name: "b", Health: HealthFailing}},
+			expected: HealthFailing,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewClusterState("test", 10)
+
+			state.ApplySnapshot(SnapshotData{Nodes: tc.nodes, Workloads: tc.workloads})
+
+			assert.Equal(t, tc.expected, state.Snapshot().Summary.Health)
+		})
+	}
+}
+
+func TestApplySnapshotPreservesClusterName(t *testing.T) {
+	// The collector does not know the configured cluster name, so the state must keep its own.
+	state := NewClusterState("prod-eu", 10)
+
+	state.ApplySnapshot(SnapshotData{Summary: Summary{KubernetesVer: "v1.34.2"}})
+
+	snap := state.Snapshot()
+	assert.Equal(t, "prod-eu", snap.Summary.ClusterName)
+	assert.Equal(t, "v1.34.2", snap.Summary.KubernetesVer)
+}
+
+func TestRevisionChangesOnMutation(t *testing.T) {
+	state := NewClusterState("test", 10)
+	initial := state.Revision()
+
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "a", Health: HealthOK}}})
+	afterSnapshot := state.Revision()
+	assert.Greater(t, afterSnapshot, initial, "a snapshot should bump the revision")
+
+	state.AddWarning(Warning{Namespace: "default", Kind: "Pod", Name: "p", Reason: "Failed"})
+	assert.Greater(t, state.Revision(), afterSnapshot, "a warning should bump the revision")
+}
+
+func TestMarkStaleDoesNotBumpRevision(t *testing.T) {
+	// Marking stale means "re-collect this", not "the canvas changed". Bumping here would publish an
+	// unchanged canvas on every event that carries no renderable data.
+	state := NewClusterState("test", 10)
+	before := state.Revision()
+
+	state.MarkStale(SectionNodes, SectionSummary)
+
+	assert.Equal(t, before, state.Revision())
+	assert.Equal(t, []Section{SectionNodes, SectionSummary}, state.TakeStale())
+}
+
+func TestTakeStaleClearsAndDeduplicates(t *testing.T) {
+	state := NewClusterState("test", 10)
+
+	state.MarkStale(SectionWorkloads)
+	state.MarkStale(SectionWorkloads, SectionCatalog)
+
+	// Repeated marks collapse, so one re-collect covers a burst of events.
+	assert.Equal(t, []Section{SectionCatalog, SectionWorkloads}, state.TakeStale())
+	assert.Nil(t, state.TakeStale(), "stale sections should be cleared once taken")
+}
+
+func TestApplySnapshotClearsStale(t *testing.T) {
+	// A full snapshot refreshes everything, so any pending re-collect request is already satisfied.
+	state := NewClusterState("test", 10)
+	state.MarkStale(SectionNodes)
+
+	state.ApplySnapshot(SnapshotData{})
+
+	assert.Nil(t, state.TakeStale())
+}
+
+func TestAddWarningUpdatesInPlace(t *testing.T) {
+	// A hot-looping pod emits the same warning repeatedly. Appending each occurrence would crowd out
+	// every other warning, so the same object/reason updates its existing entry.
+	state := NewClusterState("test", 10)
+	now := time.Now()
+
+	state.AddWarning(Warning{Namespace: "shop", Kind: "Pod", Name: "api", Reason: "BackOff", Count: 1, Timestamp: now})
+	state.AddWarning(Warning{Namespace: "shop", Kind: "Pod", Name: "api", Reason: "BackOff", Count: 7, Timestamp: now.Add(time.Second)})
+
+	warnings := state.Snapshot().Warnings
+	require.Len(t, warnings, 1)
+	assert.Equal(t, int32(7), warnings[0].Count)
+}
+
+func TestAddWarningKeepsHighestCount(t *testing.T) {
+	// Events can arrive out of order; the running count must not walk backwards.
+	state := NewClusterState("test", 10)
+	now := time.Now()
+
+	state.AddWarning(Warning{Namespace: "shop", Kind: "Pod", Name: "api", Reason: "BackOff", Count: 9, Timestamp: now})
+	state.AddWarning(Warning{Namespace: "shop", Kind: "Pod", Name: "api", Reason: "BackOff", Count: 2, Timestamp: now.Add(time.Second)})
+
+	warnings := state.Snapshot().Warnings
+	require.Len(t, warnings, 1)
+	assert.Equal(t, int32(9), warnings[0].Count)
+}
+
+func TestAddWarningDistinguishesReasons(t *testing.T) {
+	state := NewClusterState("test", 10)
+
+	state.AddWarning(Warning{Namespace: "shop", Kind: "Pod", Name: "api", Reason: "BackOff"})
+	state.AddWarning(Warning{Namespace: "shop", Kind: "Pod", Name: "api", Reason: "Unhealthy"})
+
+	assert.Len(t, state.Snapshot().Warnings, 2)
+}
+
+func TestWarningsAreCappedNewestFirst(t *testing.T) {
+	// The cap bounds memory on a noisy cluster; it must drop the oldest, not the newest.
+	state := NewClusterState("test", 3)
+	base := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+
+	for i := range 6 {
+		state.AddWarning(Warning{
+			Namespace: "default",
+			Kind:      "Pod",
+			Name:      string(rune('a' + i)),
+			Reason:    "Failed",
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	warnings := state.Snapshot().Warnings
+	require.Len(t, warnings, 3)
+	assert.Equal(t, "f", warnings[0].Name, "newest warning should be first")
+	assert.Equal(t, "d", warnings[2].Name, "oldest retained warning")
+}
+
+func TestNewClusterStateFallsBackToDefaultCap(t *testing.T) {
+	state := NewClusterState("test", 0)
+
+	for i := range defaultMaxWarnings + 5 {
+		state.AddWarning(Warning{Namespace: "default", Kind: "Pod", Name: string(rune(i)), Reason: "Failed"})
+	}
+
+	assert.Len(t, state.Snapshot().Warnings, defaultMaxWarnings)
+}
+
+func TestSnapshotIsACopy(t *testing.T) {
+	// The publisher renders outside the lock, so a snapshot must not alias the live slices.
+	state := NewClusterState("test", 10)
+	state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "node-1", Health: HealthOK}}})
+
+	snap := state.Snapshot()
+	snap.Nodes[0].Name = "mutated"
+
+	assert.Equal(t, "node-1", state.Snapshot().Nodes[0].Name)
+}
+
+func TestConcurrentAccessIsSafe(t *testing.T) {
+	// The event observer writes while the publisher reads, so this must be race-free under -race.
+	state := NewClusterState("test", 20)
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			state.AddWarning(Warning{Namespace: "default", Kind: "Pod", Name: string(rune(i)), Reason: "Failed"})
+		}()
+		go func() {
+			defer wg.Done()
+			state.ApplySnapshot(SnapshotData{Nodes: []Node{{Name: "n", Health: HealthOK}}})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = state.Snapshot()
+			state.MarkStale(SectionNodes)
+			_ = state.TakeStale()
+		}()
+	}
+	wg.Wait()
+
+	assert.NotZero(t, state.Revision())
+}
+
+func TestWorseOf(t *testing.T) {
+	assert.Equal(t, HealthFailing, WorseOf(HealthOK, HealthFailing))
+	assert.Equal(t, HealthFailing, WorseOf(HealthFailing, HealthOK))
+	assert.Equal(t, HealthDegraded, WorseOf(HealthUnknown, HealthDegraded))
+	assert.Equal(t, HealthOK, WorseOf(HealthOK, HealthOK))
+	// Unknown is worse than OK: a health that could not be determined should not read as healthy.
+	assert.Equal(t, HealthUnknown, WorseOf(HealthOK, HealthUnknown))
+}

--- a/internal/status/testdata/TestRenderEmptyCluster/canvas.golden.md
+++ b/internal/status/testdata/TestRenderEmptyCluster/canvas.golden.md
@@ -1,0 +1,27 @@
+# :white_circle: empty
+
+**Status:** Unknown
+**Nodes:** 0/0 ready
+**Pods:** 0 total, 0 unhealthy
+**Workloads:** 0 in 0 namespaces
+**Updated:** unknown
+
+## Nodes
+
+_No nodes found._
+
+## Unhealthy workloads
+
+_All workloads are healthy._
+
+## Service catalog
+
+_No workloads opted in. Add the configured label to include a workload._
+
+## Recent warnings
+
+_No recent warnings._
+
+---
+
+_Maintained by Botkube. Manual edits are overwritten on the next update._

--- a/internal/status/testdata/TestRenderFullSnapshot/canvas.golden.md
+++ b/internal/status/testdata/TestRenderFullSnapshot/canvas.golden.md
@@ -1,0 +1,42 @@
+# :red_circle: prod-eu
+
+**Status:** Failing
+**Kubernetes:** `v1.34.2`
+**Nodes:** 2/3 ready
+**Pods:** 42 total, 2 unhealthy
+**Workloads:** 17 in 4 namespaces
+**Updated:** Sat, 01 Aug 2026 12:30:00 UTC
+
+## Nodes
+
+| | Node | Ready | Schedulable | Kubelet | Reason |
+|---|---|---|---|---|---|
+| :large_green_circle: | node-1 | True | yes | `v1.34.2` |  |
+| :red_circle: | node-2 | False | yes | `v1.34.2` | KubeletNotReady |
+| :large_yellow_circle: | node-3 | True | no | `v1.34.1` | unschedulable |
+
+## Unhealthy workloads
+
+| | Kind | Namespace | Name | Ready | Restarts | Reason |
+|---|---|---|---|---|---|---|
+| :red_circle: | Pod | `shop` | api-7c9d-x2k | 0/1 | 12 | CrashLoopBackOff |
+| :large_yellow_circle: | Deployment | `shop` | web | 2/3 |  | 2/3 ready |
+
+## Service catalog
+
+| | Workload | Namespace | Container | Version | Ready | Rollout |
+|---|---|---|---|---|---|---|
+| :large_green_circle: | api | `shop` | `api` | `1.4.2` | 3/3 | settled |
+| | | | `sidecar` | `2.0.0` | | |
+| :large_yellow_circle: | web | `shop` | `web` | `2.1.0` | 2/3 | :arrows_counterclockwise: in progress |
+
+## Recent warnings
+
+| Age | Object | Reason | Count | Message |
+|---|---|---|---|---|
+| Sat, 01 Aug 2026 12:30:00 UTC | shop/Pod/api-7c9d-x2k | BackOff | x12 | Back-off restarting failed container |
+| Sat, 01 Aug 2026 12:28:00 UTC | shop/Pod/web-1 | Unhealthy | x1 | Readiness probe failed |
+
+---
+
+_Maintained by Botkube. Manual edits are overwritten on the next update._

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -111,6 +111,9 @@ func NewSocketSlack(log logrus.FieldLogger, commGroupMetadata CommGroupMetadata,
 	}, nil
 }
 
+// Client returns the underlying Slack API client.
+func (b *SocketSlack) Client() *slack.Client { return b.client }
+
 // Start starts the Slack WebSocket connection and listens for messages
 func (b *SocketSlack) Start(ctx context.Context) error {
 	b.log.Info("Starting bot")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -654,6 +654,44 @@ type Settings struct {
 	InformersResyncPeriod   time.Duration    `yaml:"informersResyncPeriod"`
 	Kubeconfig              string           `yaml:"kubeconfig"`
 	SACredentialsPathPrefix string           `yaml:"saCredentialsPathPrefix"`
+	StatusCanvas            StatusCanvas     `yaml:"statusCanvas"`
+}
+
+// StatusCanvas describes the Slack channel canvas that mirrors the current cluster status.
+//
+// Botkube keeps a channel canvas (a canvas attached to a Slack channel tab) up to date with a
+// rendered view of the cluster. Standalone canvases are intentionally not supported: Slack rejects
+// them on free plans, while channel canvases work on every tier and need no persisted canvas ID,
+// because the ID is discoverable from the channel itself.
+type StatusCanvas struct {
+	Enabled          bool                 `yaml:"enabled"`
+	Channels         []string             `yaml:"channels" validate:"required_if=Enabled true"`
+	Title            string               `yaml:"title"`
+	UpdateInterval   time.Duration        `yaml:"updateInterval"`
+	SnapshotInterval time.Duration        `yaml:"snapshotInterval"`
+	Namespaces       RegexConstraints     `yaml:"namespaces"`
+	Sections         StatusCanvasSections `yaml:"sections"`
+}
+
+// StatusCanvasSections configures which sections the canvas renders.
+type StatusCanvasSections struct {
+	Summary   StatusCanvasSection        `yaml:"summary"`
+	Nodes     StatusCanvasSection        `yaml:"nodes"`
+	Workloads StatusCanvasSection        `yaml:"workloads"`
+	Catalog   StatusCanvasCatalogSection `yaml:"catalog"`
+	Warnings  StatusCanvasSection        `yaml:"warnings"`
+}
+
+// StatusCanvasSection configures a single canvas section.
+type StatusCanvasSection struct {
+	Disabled bool `yaml:"disabled"`
+	Limit    int  `yaml:"limit"`
+}
+
+// StatusCanvasCatalogSection configures the opt-in service catalog section.
+type StatusCanvasCatalogSection struct {
+	StatusCanvasSection `yaml:",inline"`
+	LabelSelector       string `yaml:"labelSelector"`
 }
 
 // Formatter log formatter

--- a/pkg/config/default.yaml
+++ b/pkg/config/default.yaml
@@ -10,6 +10,24 @@ settings:
     name: botkube-system
     namespace: botkube
 
+  statusCanvas:
+    enabled: false
+    title: "{{ .ClusterName }} cluster status"
+    updateInterval: "10s"
+    snapshotInterval: "5m"
+    sections:
+      summary:
+        limit: 0
+      nodes:
+        limit: 25
+      workloads:
+        limit: 25
+      catalog:
+        limit: 50
+        labelSelector: "botkube.io/canvas=true"
+      warnings:
+        limit: 15
+
 plugins:
   cacheDir: "/tmp"
 

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -139,6 +139,31 @@ settings:
   informersResyncPeriod: 30m0s
   kubeconfig: kubeconfig-from-env
   saCredentialsPathPrefix: ""
+  statusCanvas:
+    enabled: false
+    channels: []
+    title: '{{ .ClusterName }} cluster status'
+    updateInterval: 10s
+    snapshotInterval: 5m0s
+    namespaces:
+      include: []
+    sections:
+      summary:
+        disabled: false
+        limit: 0
+      nodes:
+        disabled: false
+        limit: 25
+      workloads:
+        disabled: false
+        limit: 25
+      catalog:
+        disabled: false
+        limit: 50
+        labelSelector: botkube.io/canvas=true
+      warnings:
+        disabled: false
+        limit: 15
 configWatcher:
   enabled: false
   remote:

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -65,6 +65,31 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						    informersResyncPeriod: 0s
 						    kubeconfig: ""
 						    saCredentialsPathPrefix: ""
+						    statusCanvas:
+						        enabled: false
+						        channels: []
+						        title: ""
+						        updateInterval: 0s
+						        snapshotInterval: 0s
+						        namespaces:
+						            include: []
+						        sections:
+						            summary:
+						                disabled: false
+						                limit: 0
+						            nodes:
+						                disabled: false
+						                limit: 0
+						            workloads:
+						                disabled: false
+						                limit: 0
+						            catalog:
+						                disabled: false
+						                limit: 0
+						                labelSelector: ""
+						            warnings:
+						                disabled: false
+						                limit: 0
 						configWatcher:
 						    enabled: false
 						    remote:


### PR DESCRIPTION
Add the ability for botkube to create and keep updated a Slack Canvas with cluster status.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add the ability for botkube to create and keep updated a Slack Canvas
with cluster status.


## Testing

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
